### PR TITLE
MPS GPU support

### DIFF
--- a/src/cebmf_torch/utils/device.py
+++ b/src/cebmf_torch/utils/device.py
@@ -1,26 +1,34 @@
 import torch
 
 
-def get_device(prefer_cuda: bool = True) -> torch.device:
-    """
-    Get the default torch device (CUDA if available, else CPU).
 
-    Parameters
-    ----------
-    prefer_cuda : bool, optional
-        If True, prefer CUDA if available. Defaults to True.
+def get_device(prefer_gpu: bool = True) -> torch.device:
+    """Get the best available device.
 
-    Returns
-    -------
-    torch.device
-        The selected device ("cuda" or "cpu").
+    Priority order:
+    1. CUDA (NVIDIA GPUs)
+    2. MPS (Apple Silicon GPUs)
+    3. CPU (fallback)
+
+    Args:
+        prefer_gpu: Whether to prefer GPU over CPU
+
+    Returns:
+        torch.device: The selected device
     """
-    if prefer_cuda and torch.cuda.is_available():
+    if not prefer_gpu:
+        return torch.device("cpu")
+
+    if torch.cuda.is_available():
+
         return torch.device("cuda")
-    return torch.device("cpu")
+    elif torch.backends.mps.is_available():
+        return torch.device("mps")
+    else:
+        return torch.device("cpu")
 
 
-def to_device(x, device=None):
+def to_device(x: torch.Tensor, device: torch.device | None = None):
     """
     Move a tensor or module to the specified device.
 
@@ -38,6 +46,4 @@ def to_device(x, device=None):
     """
     if device is None:
         device = get_device()
-    if hasattr(x, "to"):
-        return x.to(device)
-    return x
+    return x.to(device)

--- a/src/cebmf_torch/utils/device.py
+++ b/src/cebmf_torch/utils/device.py
@@ -1,7 +1,6 @@
 import torch
 
 
-
 def get_device(prefer_gpu: bool = True) -> torch.device:
     """Get the best available device.
 
@@ -20,7 +19,6 @@ def get_device(prefer_gpu: bool = True) -> torch.device:
         return torch.device("cpu")
 
     if torch.cuda.is_available():
-
         return torch.device("cuda")
     elif torch.backends.mps.is_available():
         return torch.device("mps")

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -86,7 +86,7 @@ def test_device_handling():
 
     # Test default device
     model1 = cEBMF(data=Y, K=3)
-    assert model1.device.type in ["cpu", "cuda"]
+    assert model1.device.type in ["cpu", "cuda", "mps"]
 
     # Test explicit device
     device = torch.device("cpu")


### PR DESCRIPTION
Allows `pytorch` to find the Apple silicon GPUs (`mps`).

Unfortunately not all operators have been implemented on these GPUs so some warnings arise e.g.  

```
ebmf_torch/src/cebmf_torch/torch_main.py:44: UserWarning: The operator 'aten::linalg_svd' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/mps/MPSFallback.mm:15.)
    U, S, Vh = torch.linalg.svd(Y_for_init, full_matrices=False)
```