### PR TITLE
Fix link to examples rtd

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
     # rust: "1.70"
     # golang: "1.20"
   jobs:
-    post_build:
+    pre_build:
       - mkdir -p docs/source/notebooks/
       - cp -r examples/*.ipynb docs/source/notebooks/
 


### PR DESCRIPTION
Copies notebooks to a directory in source in the rtd yaml so that they can be displayed after the build.