### PR TITLE
Feat/override_initialise_factors

### DIFF
--- a/examples/model_RNA_ATAC.ipynb
+++ b/examples/model_RNA_ATAC.ipynb
@@ -581,7 +581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "dbd61465",
    "metadata": {},
    "outputs": [],
@@ -597,7 +597,7 @@
     "    K=K,\n",
     "    allow_backfitting=False\n",
     ")\n",
-    "mycebmfR.initialise_factors()\n",
+    "mycebmfR.initialise_factors(L=mycebmf0R.L.clone(), F=mycebmf0R.F.clone())\n",
     "\n",
     "mycebmfA = cEBMF(\n",
     "    data=X_obs_ATAC,\n",
@@ -610,13 +610,7 @@
     "    K=K,\n",
     "    allow_backfitting=False\n",
     ")\n",
-    "mycebmfA.initialise_factors()\n",
-    "\n",
-    "# Override initial values with previous fits\n",
-    "mycebmfR.L = mycebmf0R.L.clone()\n",
-    "mycebmfR.F = mycebmf0R.F.clone()\n",
-    "mycebmfA.L = mycebmf0A.L.clone()\n",
-    "mycebmfA.F = mycebmf0A.F.clone()"
+    "mycebmfA.initialise_factors(L=mycebmf0A.L.clone(), F=mycebmf0A.F.clone())"
    ]
   },
   {

--- a/src/cebmf_torch/cebmf/_initialisation.py
+++ b/src/cebmf_torch/cebmf/_initialisation.py
@@ -165,3 +165,34 @@ INIT_STRATEGIES = {
     "random": random_initialise,
     "zero": zero_initialise,
 }
+
+
+def user_provided_factors(L: Tensor, F: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
+    """
+    Use user-provided factor matrices.
+
+    Parameters
+    ----------
+    L : Tensor
+        User-provided L matrix (N, K)
+    F : Tensor
+        User-provided F matrix (P, K)
+    N : int
+        Number of rows of L (for validation)
+    P : int
+        Number of rows of F (for validation)
+    K : int
+        Number of factors i.e. columns of L and F (for validation)
+    device : torch.device
+        Target device
+
+    Returns
+    -------
+    tuple of Tensor
+        Tuple of (L, F) tensors on the specified device.
+    """
+    if L.shape != (N, K):
+        raise ValueError(f"Provided L has shape {L.shape}, expected ({N}, {K})")
+    if F.shape != (P, K):
+        raise ValueError(f"Provided F has shape {F.shape}, expected ({P}, {K})")
+    return L.to(device), F.to(device)

--- a/src/cebmf_torch/cebmf/_initialisation.py
+++ b/src/cebmf_torch/cebmf/_initialisation.py
@@ -1,0 +1,166 @@
+from typing import Protocol
+
+import torch
+from torch import Tensor
+
+RANDOM_INIT_SCALE = 0.01
+
+
+class InitialisationStrategy(Protocol):
+    """
+    Protocol for factor initialization strategies.
+
+    Methods
+    -------
+    __call__(Y, N, P, K, device)
+        Initialize L and F matrices.
+    """
+
+    def __call__(self, Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
+        """
+        Initialize L and F matrices.
+
+        Parameters
+        ----------
+        Y : Tensor
+            Input data tensor (N, P)
+        N : int
+            Number of rows
+        P : int
+            Number of columns
+        K : int
+            Number of factors
+        device : torch.device
+            Target device
+
+        Returns
+        -------
+        tuple of Tensor
+            Tuple of (L, F) tensors
+        """
+        ...
+
+@torch.no_grad()
+def _impute_nan(Y: Tensor) -> Tensor:
+    """
+    Column-mean imputation for NaNs in a tensor (for SVD init only).
+
+    Parameters
+    ----------
+    Y : Tensor
+        Input data tensor with possible NaNs.
+
+    Returns
+    -------
+    Tensor
+        Imputed tensor with NaNs replaced by column means.
+    """
+    mask = ~torch.isnan(Y)
+    if not mask.any():
+        return Y
+    col_means = torch.nanmean(Y, dim=0)
+    Y_imp = Y.clone()
+    idx = torch.where(~mask)
+    Y_imp[idx] = col_means[idx[1]]
+    return Y_imp
+
+
+@torch.no_grad()
+def svd_initialise(Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
+    """
+    SVD-based initialization strategy for factor matrices.
+
+    Parameters
+    ----------
+    Y : Tensor
+        Input data tensor (N, P)
+    N : int
+        Number of rows
+    P : int
+        Number of columns
+    K : int
+        Number of factors
+    device : torch.device
+        Target device
+
+    Returns
+    -------
+    tuple of Tensor
+        Tuple of (L, F) tensors
+    """
+    Y_for_init = _impute_nan(Y)
+    U, S, Vh = torch.linalg.svd(Y_for_init, full_matrices=False)
+    K_actual = min(K, S.shape[0])
+    L = (U[:, :K_actual] * S[:K_actual]).contiguous()
+    F = Vh[:K_actual, :].T.contiguous()
+
+    # Pad with zeros if K > rank
+    if K_actual < K:
+        L = torch.cat([L, torch.zeros(N, K - K_actual, device=device)], dim=1)
+        F = torch.cat([F, torch.zeros(P, K - K_actual, device=device)], dim=1)
+
+    return L, F
+
+
+@torch.no_grad()
+def random_initialise(Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
+    """
+    Random initialization strategy for factor matrices.
+
+    Parameters
+    ----------
+    Y : Tensor
+        Input data tensor (N, P)
+    N : int
+        Number of rows
+    P : int
+        Number of columns
+    K : int
+        Number of factors
+    device : torch.device
+        Target device
+
+    Returns
+    -------
+    tuple of Tensor
+        Tuple of (L, F) tensors
+    """
+    L = torch.randn(N, K, device=device) * RANDOM_INIT_SCALE
+    F = torch.randn(P, K, device=device) * RANDOM_INIT_SCALE
+    return L, F
+
+
+@torch.no_grad()
+def zero_initialise(Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
+    """
+    Zero initialization strategy for factor matrices.
+
+    Parameters
+    ----------
+    Y : Tensor
+        Input data tensor (N, P)
+    N : int
+        Number of rows
+    P : int
+        Number of columns
+    K : int
+        Number of factors
+    device : torch.device
+        Target device
+
+    Returns
+    -------
+    tuple of Tensor
+        Tuple of (L, F) tensors
+    """
+    L = torch.zeros(N, K, device=device)
+    F = torch.zeros(P, K, device=device)
+    return L, F
+
+
+# Registry for initialization strategies
+INIT_STRATEGIES = {
+    "svd": svd_initialise,
+    "random": random_initialise,
+    "zero": zero_initialise,
+}

--- a/src/cebmf_torch/cebmf/_initialisation.py
+++ b/src/cebmf_torch/cebmf/_initialisation.py
@@ -40,6 +40,7 @@ class InitialisationStrategy(Protocol):
         """
         ...
 
+
 @torch.no_grad()
 def _impute_nan(Y: Tensor) -> Tensor:
     """

--- a/src/cebmf_torch/torch_main.py
+++ b/src/cebmf_torch/torch_main.py
@@ -163,7 +163,7 @@ class cEBMF:
             warn("Provided L without F; ignoring L and using svd for initialization.")
             _use_strategy("svd")
         elif L is not None and F is not None:
-            user_provided_factors(L, F, self.N, self.P, self.model.K, self.device)
+            self.L, self.F = user_provided_factors(L, F, self.N, self.P, self.model.K, self.device)
 
         elif method not in INIT_STRATEGIES:
             raise ValueError(f"Unknown initialization method '{method}'. Available: {list(INIT_STRATEGIES.keys())}")

--- a/src/cebmf_torch/torch_main.py
+++ b/src/cebmf_torch/torch_main.py
@@ -140,7 +140,7 @@ class cEBMF:
     @torch.no_grad()
     def initialise_factors(self, method: str = "svd", *, L: Tensor | None = None, F: Tensor | None = None):
         """
-        Initialize factor matrices using the specified method.
+        Initialize factor matrices using the specified method, or user-provided initial factors.
 
         Parameters
         ----------

--- a/src/cebmf_torch/torch_main.py
+++ b/src/cebmf_torch/torch_main.py
@@ -1,156 +1,18 @@
 import math
 from dataclasses import dataclass
 from enum import StrEnum, auto
-from typing import Protocol
 
 import torch
 from torch import Tensor
 
+from cebmf_torch.cebmf._initialisation import INIT_STRATEGIES
 from cebmf_torch.priors import PRIOR_REGISTRY
 from cebmf_torch.utils.device import get_device
 from cebmf_torch.utils.maths import safe_tensor_to_float
 
 # Add at top of file after imports:
 NUMERICAL_EPS = 1e-12
-RANDOM_INIT_SCALE = 0.01
 DEFAULT_PRUNE_THRESH = 1 - 1e-3
-
-
-# Initialization strategies
-class InitialisationStrategy(Protocol):
-    """
-    Protocol for factor initialization strategies.
-
-    Methods
-    -------
-    __call__(Y, N, P, K, device)
-        Initialize L and F matrices.
-    """
-
-    def __call__(self, Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
-        """
-        Initialize L and F matrices.
-
-        Parameters
-        ----------
-        Y : Tensor
-            Input data tensor (N, P)
-        N : int
-            Number of rows
-        P : int
-            Number of columns
-        K : int
-            Number of factors
-        device : torch.device
-            Target device
-
-        Returns
-        -------
-        tuple of Tensor
-            Tuple of (L, F) tensors
-        """
-        ...
-
-
-@torch.no_grad()
-def svd_initialise(Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
-    """
-    SVD-based initialization strategy for factor matrices.
-
-    Parameters
-    ----------
-    Y : Tensor
-        Input data tensor (N, P)
-    N : int
-        Number of rows
-    P : int
-        Number of columns
-    K : int
-        Number of factors
-    device : torch.device
-        Target device
-
-    Returns
-    -------
-    tuple of Tensor
-        Tuple of (L, F) tensors
-    """
-    Y_for_init = _impute_nan(Y)
-    U, S, Vh = torch.linalg.svd(Y_for_init, full_matrices=False)
-    K_actual = min(K, S.shape[0])
-    L = (U[:, :K_actual] * S[:K_actual]).contiguous()
-    F = Vh[:K_actual, :].T.contiguous()
-
-    # Pad with zeros if K > rank
-    if K_actual < K:
-        L = torch.cat([L, torch.zeros(N, K - K_actual, device=device)], dim=1)
-        F = torch.cat([F, torch.zeros(P, K - K_actual, device=device)], dim=1)
-
-    return L, F
-
-
-@torch.no_grad()
-def random_initialise(Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
-    """
-    Random initialization strategy for factor matrices.
-
-    Parameters
-    ----------
-    Y : Tensor
-        Input data tensor (N, P)
-    N : int
-        Number of rows
-    P : int
-        Number of columns
-    K : int
-        Number of factors
-    device : torch.device
-        Target device
-
-    Returns
-    -------
-    tuple of Tensor
-        Tuple of (L, F) tensors
-    """
-    L = torch.randn(N, K, device=device) * RANDOM_INIT_SCALE
-    F = torch.randn(P, K, device=device) * RANDOM_INIT_SCALE
-    return L, F
-
-
-@torch.no_grad()
-def zero_initialise(Y: Tensor, N: int, P: int, K: int, device: torch.device) -> tuple[Tensor, Tensor]:
-    """
-    Zero initialization strategy for factor matrices.
-
-    Parameters
-    ----------
-    Y : Tensor
-        Input data tensor (N, P)
-    N : int
-        Number of rows
-    P : int
-        Number of columns
-    K : int
-        Number of factors
-    device : torch.device
-        Target device
-
-    Returns
-    -------
-    tuple of Tensor
-        Tuple of (L, F) tensors
-    """
-    L = torch.zeros(N, K, device=device)
-    F = torch.zeros(P, K, device=device)
-    return L, F
-
-
-# Registry for initialization strategies
-INIT_STRATEGIES = {
-    "svd": svd_initialise,
-    "random": random_initialise,
-    "zero": zero_initialise,
-}
 
 
 @dataclass
@@ -690,28 +552,3 @@ def normal_means_loglik(
         return out
     else:
         raise ValueError("reduce must be 'sum', 'mean', or 'none'")
-
-
-@torch.no_grad()
-def _impute_nan(Y: Tensor) -> Tensor:
-    """
-    Column-mean imputation for NaNs in a tensor (for SVD init only).
-
-    Parameters
-    ----------
-    Y : Tensor
-        Input data tensor with possible NaNs.
-
-    Returns
-    -------
-    Tensor
-        Imputed tensor with NaNs replaced by column means.
-    """
-    mask = ~torch.isnan(Y)
-    if not mask.any():
-        return Y
-    col_means = torch.nanmean(Y, dim=0)
-    Y_imp = Y.clone()
-    idx = torch.where(~mask)
-    Y_imp[idx] = col_means[idx[1]]
-    return Y_imp

--- a/tests/test_cebmf_factor_initialisation.py
+++ b/tests/test_cebmf_factor_initialisation.py
@@ -1,11 +1,31 @@
-import torch
 import pytest
+import torch
 
-from cebmf_torch.cebmf._initialisation import INIT_STRATEGIES, user_provided_factors
+from cebmf_torch.cebmf._initialisation import random_initialise, svd_initialise, user_provided_factors, zero_initialise
 
 
-def test_user_provided_factors():
-    N, P, K = 5, 4, 3
+@pytest.fixture
+def N() -> int:
+    return 5
+
+
+@pytest.fixture
+def P() -> int:
+    return 4
+
+
+@pytest.fixture
+def K() -> int:
+    return 3
+
+
+@pytest.fixture
+def Y(N: int, P: int) -> torch.Tensor:
+    torch.manual_seed(42)
+    return torch.randn(N, P)
+
+
+def test_user_provided_factors(N: int, P: int, K: int) -> None:
     device = torch.device("cpu")
     L_user = torch.randn(N, K, device=device)
     F_user = torch.randn(P, K, device=device)
@@ -16,8 +36,7 @@ def test_user_provided_factors():
     assert torch.allclose(F_out, F_user), "F matrix not correctly returned"
 
 
-def test_user_provided_factors_shape_mismatch():
-    N, P, K = 5, 4, 3
+def test_user_provided_factors_shape_mismatch(N: int, P: int, K: int) -> None:
     device = torch.device("cpu")
     L_user = torch.randn(N + 1, K, device=device)  # Incorrect shape
     F_user = torch.randn(P, K, device=device)
@@ -30,3 +49,28 @@ def test_user_provided_factors_shape_mismatch():
 
     with pytest.raises(ValueError, match=r"Provided F has shape torch\.Size\(\[5, 3\]\), expected \(4, 3\)"):
         user_provided_factors(L_user, F_user, N, P, K, device)
+
+
+def test_zero_initialise(Y: torch.Tensor, N: int, P: int, K: int) -> None:
+    device = torch.device("cpu")
+    L, F = zero_initialise(Y, N, P, K, device)
+    assert L.shape == (N, K), "L shape incorrect"
+    assert F.shape == (P, K), "F shape incorrect"
+    assert torch.all(L == 0), "L not all zeros"
+    assert torch.all(F == 0), "F not all zeros"
+
+
+def test_random_initialise(Y: torch.Tensor, N: int, P: int, K: int) -> None:
+    device = torch.device("cpu")
+    L, F = random_initialise(Y, N, P, K, device)
+    assert L.shape == (N, K), "L shape incorrect"
+    assert F.shape == (P, K), "F shape incorrect"
+    assert not torch.all(L == 0), "L should not be all zeros"
+    assert not torch.all(F == 0), "F should not be all zeros"
+
+
+def test_svd_initialise(Y: torch.Tensor, N: int, P: int, K: int) -> None:
+    device = torch.device("cpu")
+    L, F = svd_initialise(Y, N, P, K, device)
+    assert L.shape == (N, K), "L shape incorrect"
+    assert F.shape == (P, K), "F shape incorrect"

--- a/tests/test_cebmf_factor_initialisation.py
+++ b/tests/test_cebmf_factor_initialisation.py
@@ -1,0 +1,32 @@
+import torch
+import pytest
+
+from cebmf_torch.cebmf._initialisation import INIT_STRATEGIES, user_provided_factors
+
+
+def test_user_provided_factors():
+    N, P, K = 5, 4, 3
+    device = torch.device("cpu")
+    L_user = torch.randn(N, K, device=device)
+    F_user = torch.randn(P, K, device=device)
+
+    L_out, F_out = user_provided_factors(L_user, F_user, N, P, K, device)
+
+    assert torch.allclose(L_out, L_user), "L matrix not correctly returned"
+    assert torch.allclose(F_out, F_user), "F matrix not correctly returned"
+
+
+def test_user_provided_factors_shape_mismatch():
+    N, P, K = 5, 4, 3
+    device = torch.device("cpu")
+    L_user = torch.randn(N + 1, K, device=device)  # Incorrect shape
+    F_user = torch.randn(P, K, device=device)
+
+    with pytest.raises(ValueError, match=r"Provided L has shape torch\.Size\(\[6, 3\]\), expected \(5, 3\)"):
+        user_provided_factors(L_user, F_user, N, P, K, device)
+
+    L_user = torch.randn(N, K, device=device)
+    F_user = torch.randn(P + 1, K, device=device)  # Incorrect shape
+
+    with pytest.raises(ValueError, match=r"Provided F has shape torch\.Size\(\[5, 3\]\), expected \(4, 3\)"):
+        user_provided_factors(L_user, F_user, N, P, K, device)


### PR DESCRIPTION
In the `model_RNA_ATAC.ipynb` example there was a hack to override the initialisation of factors with previously calculated factors.

This implements a new `user_provided_factors` strategy for initialisation, although it doesn't fit in the strategy pattern of the other initialisation methods.