### PR TITLE
Spike penalty: use sum of logs instead of log of sum?

### DIFF
--- a/src/cebmf_torch/cebnm/cash_solver.py
+++ b/src/cebmf_torch/cebnm/cash_solver.py
@@ -74,9 +74,9 @@ def pen_loglik_loss(pred_pi, marginal_log_lik, penalty=1.5, epsilon=1e-10):
     first_sum = torch.sum(torch.log(inner_sum))  # scalar
 
     if penalty > 1:
-        # penalize the (assumed) spike component's total mass in the batch
-        pi_clamped = torch.clamp(torch.sum(pred_pi[:, 0]), min=epsilon)
-        penalized_log_likelihood_value = first_sum + (penalty - 1) * torch.log(pi_clamped)
+        # penalize per-gene spike probability (Dirichlet-like prior on component 0)
+        log_pi0 = torch.log(torch.clamp(pred_pi[:, 0], min=epsilon))
+        penalized_log_likelihood_value = first_sum + (penalty - 1) * torch.sum(log_pi0)
     else:
         penalized_log_likelihood_value = first_sum
 

--- a/src/cebmf_torch/cebnm/cov_sharp_gb_prior.py
+++ b/src/cebmf_torch/cebnm/cov_sharp_gb_prior.py
@@ -93,10 +93,9 @@ def cgb_loss(pi_1, pi_2, mu_2, sigma2_sq, targets, se, penalty=1.5, eps=1e-8):
 
     log_mix = torch.logaddexp(torch.log(pi_1.clamp_min(eps)) + logp1, torch.log(pi_2.clamp_min(eps)) + logp2)
     if penalty > 1.0:
-        # take mean spike prob for stability
-        pi0_clamped = pi_1.mean().clamp_min(eps)
-        penalty_term = (penalty - 1.0) * torch.log(pi0_clamped)
-        log_mix = log_mix + penalty_term
+        # penalize per-gene spike probability (Dirichlet-like prior on component 0)
+        log_pi0 = torch.log(pi_1.clamp_min(eps))
+        log_mix = log_mix + (penalty - 1.0) * log_pi0
     return -(log_mix.mean())
 
 


### PR DESCRIPTION
## Summary

The spike penalty in `pen_loglik_loss` (`cash_solver.py`) and `cgb_loss` (`cov_sharp_gb_prior.py`) aggregates spike probabilities across observations $i$ before taking the log:

- `cash_solver.py`: $\log(\sum_i \pi_{i,0})$
- `cov_sharp_gb_prior.py`: $\log(mean_i  \pi_{i,0})$

The code comments suggest this aggregation may be intentional, but for discussion, I propose changing both to $\sum_i \log(\pi_{i,0})$ so that the penalty decomposes per observation $i$, consistent with the per-observation structure of the objective.

## Motivation

- The current formulation produces a gradient w.r.t. $\pi_{j,0}$ that is identical across all observations in the batch ($(\lambda-1) / \sum_i \pi_{i,0}$). The proposed version gives observation-specific gradients ($(\lambda-1) / \pi_{j,0}$), applying stronger pressure to observations with low spike probability.
- The current penalty can vanish when spike probabilities across the batch happen to be close to 1.

## Changes

- `src/cebmf_torch/cebnm/cash_solver.py`: clamp and log per observation, then sum.
- `src/cebmf_torch/cebnm/cov_sharp_gb_prior.py`: same pattern, replacing `pi_1.mean()` with per-observation log.