### PR TITLE
Fix warm-starting for learned priors: return trained model_param instead of input

### DIFF
--- a/src/cebmf_torch/priors/learned.py
+++ b/src/cebmf_torch/priors/learned.py
@@ -144,6 +144,6 @@ class LearnedBuilder(PriorBuilder):
             post_mean=obj.post_mean,
             post_mean2=obj.post_mean2,
             loss=float(obj.loss),
-            model_param=model_param,
+            model_param=obj.model_param,
             pi0_null=pi0_null,
         )


### PR DESCRIPTION
## Summary

- `LearnedBuilder.fit()` returns the *input* `model_param` in the `Prior` result instead of the *trained* state from the solver, so warm-starting never activates across cEBMF iterations.
- One-line fix: `model_param=model_param` → `model_param=obj.model_param`.

## Problem

In `priors/learned.py`, line 147:

```python
return Prior(
    ...
    model_param=model_param,   # ← input value, always None on first call
    ...
)
```

Each solver (CASH, CGB, EMDN, etc.) trains a neural network and returns the trained state in `obj.model_param` (e.g., `cash_posterior_means` returns `model_cash.state_dict()` at `cash_solver.py:265`). But `LearnedBuilder.fit()` discards this and passes through its input argument.

In the cEBMF loop (`cebmf.py:293`), the returned `model_param` is stored for the next iteration:

```python
self.model_state_L[k] = resL.model_param
```

Since `resL.model_param` is always the (unchanged) input, `model_state_L[k]` stays `None` after the first call, and every subsequent call trains from scratch.

## Fix

```diff
         return Prior(
             post_mean=obj.post_mean,
             post_mean2=obj.post_mean2,
             loss=float(obj.loss),
-            model_param=model_param,
+            model_param=obj.model_param,
             pi0_null=pi0_null,
         )
```

## Impact

Affects all learned priors: CASH, CGB, CGB_SHARP, EMDN, SPIKED_EMDN. After this fix, networks trained in iteration *t* are warm-started in iteration *t+1*, reducing redundant training and improving convergence within the cEBMF loop.

## Verification

We tested locally against the current `main` (commit 6ec03fd) on macOS / Python 3.11 / PyTorch 2.x (CPU).

**1. Existing tests pass (no regressions):**

All learned-prior tests pass with the fix:

| Test | Result |
|:-----|:-------|
| `test_cash_posterior.py` | PASS |
| `test_emdn_posterior.py` | PASS |
| `test_gcbf_posterior.py` | PASS |
| `test_generalized_binary.py` (4 tests) | PASS |
| `test_cebmf_factor_initialisation.py` (8 tests) | PASS |

(12 pre-existing failures in other tests are all numpy 2.x incompatibility, unrelated to this change.)

**2. `model_state_L[k]` is not None after first iteration:**

Ran a rank-1 cEBMF fit with `prior_L="cash"` and verified that `model_state_L[0]` contains a non-empty state dict after one call to `iter_once()`. Before the fix, it was `None`.

**3. Warm-start improves convergence:**

Compared 6 cEBMF iterations (CASH prior, `n_epochs=10` per iteration) with and without warm-starting (simulated the bug by resetting `model_state` to `None` after each iteration):

| Condition | ELBO after 6 iterations |
|:----------|:------------------------|
| With warm-start (fix) | 3786.7 |
| Without warm-start (bug) | 3754.1 |

Warm-starting achieves a higher ELBO (+0.87%) in the same number of iterations. The cold-start loss trace also shows erratic jumps between iterations because the network retrains from scratch each time.