### PR TITLE
Add LC-ASH and PO-LC-ASH solvers: linear covariate-modulated mixture weights

### DIFF
--- a/src/cebmf_torch/cebnm/__init__.py
+++ b/src/cebmf_torch/cebnm/__init__.py
@@ -5,12 +5,15 @@ from .cash_solver import cash_posterior_means
 from .cov_gb_prior import cgb_posterior_means
 from .cov_sharp_gb_prior import sharp_cgb_posterior_means
 from .emdn import emdn_posterior_means
+from .lcash import lcash_posterior_means, po_lcash_posterior_means
 from .spiked_emdn import spiked_emdn_posterior_means
 
 __all__ = [
     "cash_posterior_means",
     "cgb_posterior_means",
     "emdn_posterior_means",
+    "lcash_posterior_means",
+    "po_lcash_posterior_means",
     "sharp_cgb_posterior_means",
     "spiked_emdn_posterior_means",
 ]

--- a/src/cebmf_torch/cebnm/lcash.py
+++ b/src/cebmf_torch/cebnm/lcash.py
@@ -22,7 +22,6 @@ from cebmf_torch.ebnm.ash import PriorType, ash
 from cebmf_torch.utils.distribution_operation import get_data_loglik_normal_torch
 from cebmf_torch.utils.mixture import autoselect_scales_mix_norm
 
-
 # ============================================================
 # Model classes
 # ============================================================
@@ -58,8 +57,7 @@ class LcashNet(nn.Module):
         # Small random perturbation breaks symmetry across features.
         # Starting from exact zeros leads Adam to different local
         # optima on high-dimensional feature sets (F > 100).
-        nn.init.normal_(self.linear.weight, mean=0.0, std=0.01,
-                        generator=generator)
+        nn.init.normal_(self.linear.weight, mean=0.0, std=0.01, generator=generator)
         if log_pi_init is not None:
             with torch.no_grad():
                 self.linear.bias.copy_(log_pi_init)
@@ -120,9 +118,7 @@ class PropOddsLcashNet(nn.Module):
         self._K = K
 
     @staticmethod
-    def _init_cutpoints_from_pi(
-        log_pi_init: torch.Tensor, K: int
-    ) -> torch.Tensor:
+    def _init_cutpoints_from_pi(log_pi_init: torch.Tensor, K: int) -> torch.Tensor:
         """Initialise cut-points so that sigma(theta_k) approx cumprob_k.
 
         At initialisation w ~ 0, so s_i ~ 0 for all genes.  Then
@@ -226,7 +222,7 @@ def _nanstandardise(X: torch.Tensor) -> torch.Tensor:
 
     # Population std on observed values
     diff = torch.where(mask, X - mu, torch.zeros_like(X))
-    var = (diff ** 2).sum(dim=0) / safe_counts  # (F,)
+    var = (diff**2).sum(dim=0) / safe_counts  # (F,)
     sd = var.sqrt()
 
     # Standardise observed, zero-fill missing
@@ -277,8 +273,7 @@ def _select_grid(
         None when ``ash_init=False``.
     """
     if ash_init:
-        ash_result = ash(betahat, sebetahat, prior=PriorType.NORM,
-                         verbose=False, optimizer="lbfgs", mult=mult)
+        ash_result = ash(betahat, sebetahat, prior=PriorType.NORM, verbose=False, optimizer="lbfgs", mult=mult)
         pi_full = ash_result.pi
         active = pi_full > ash_threshold
         # Fallback: ensure at least K=2 (spike + one slab)
@@ -295,8 +290,7 @@ def _select_grid(
         log_pi_init = log_pi_init.to(device=device, dtype=torch.float32)
         return scale, log_pi_init
 
-    scale = autoselect_scales_mix_norm(betahat=betahat, sebetahat=sebetahat,
-                                       mult=mult)
+    scale = autoselect_scales_mix_norm(betahat=betahat, sebetahat=sebetahat, mult=mult)
     if not isinstance(scale, torch.Tensor):
         scale = torch.as_tensor(scale, dtype=torch.float32, device=device)
     else:
@@ -331,8 +325,10 @@ def _train_model(
     loc = torch.zeros_like(scale)
     with torch.no_grad():
         logL_all = get_data_loglik_normal_torch(
-            betahat=betahat, sebetahat=sebetahat,
-            location=loc, scale=scale,
+            betahat=betahat,
+            sebetahat=sebetahat,
+            location=loc,
+            scale=scale,
         )
 
     # Seeded manual batching (5x faster than DataLoader due to
@@ -358,8 +354,7 @@ def _train_model(
             epoch_loss += loss.item()
         final_epoch_loss = epoch_loss
         if verbose and (epoch + 1) % 50 == 0:
-            print(f"[{label}] Epoch {epoch + 1}/{n_epochs} | "
-                  f"Loss: {epoch_loss / n_batches:.4f}")
+            print(f"[{label}] Epoch {epoch + 1}/{n_epochs} | Loss: {epoch_loss / n_batches:.4f}")
 
     return final_epoch_loss
 
@@ -467,8 +462,7 @@ def _fit_lcash(
         n_epochs = 200
 
     X_scaled, betahat, sebetahat = _prepare_inputs(X, betahat, sebetahat, device)
-    scale, log_pi_init = _select_grid(betahat, sebetahat, mult, ash_init,
-                                       ash_threshold, device)
+    scale, log_pi_init = _select_grid(betahat, sebetahat, mult, ash_init, ash_threshold, device)
 
     # Local RNG for reproducible weight init and batch ordering.
     # Does not mutate global torch RNG state.
@@ -476,8 +470,7 @@ def _fit_lcash(
     rng.manual_seed(seed)
 
     K = scale.shape[0]
-    model = model_class(X_scaled.shape[1], K, log_pi_init=log_pi_init,
-                        generator=rng).to(device)
+    model = model_class(X_scaled.shape[1], K, log_pi_init=log_pi_init, generator=rng).to(device)
     _warm_start(model, model_param, label)
 
     # Build optimizer: weight_decay on feature weights only.
@@ -497,12 +490,27 @@ def _fit_lcash(
     optimizer = torch.optim.Adam(param_groups, lr=lr)
 
     final_loss = _train_model(
-        model, optimizer, X_scaled, betahat, sebetahat, scale,
-        n_epochs, batch_size, penalty, verbose, label, seed=seed,
+        model,
+        optimizer,
+        X_scaled,
+        betahat,
+        sebetahat,
+        scale,
+        n_epochs,
+        batch_size,
+        penalty,
+        verbose,
+        label,
+        seed=seed,
     )
 
     post_mean, post_mean2, post_sd, all_pi_values = _compute_posteriors(
-        model, X_scaled, betahat, sebetahat, scale, device,
+        model,
+        X_scaled,
+        betahat,
+        sebetahat,
+        scale,
+        device,
     )
 
     return cash_PosteriorMeanNorm(
@@ -589,12 +597,22 @@ def lcash_posterior_means(
         scale (K,), loss, model_param (state dict for warm-starting).
     """
     return _fit_lcash(
-        X, betahat, sebetahat,
-        model_class=LcashNet, label="LC-ASH",
-        n_epochs=n_epochs, batch_size=batch_size, lr=lr,
-        weight_decay=weight_decay, penalty=penalty,
-        mult=mult, ash_init=ash_init, ash_threshold=ash_threshold,
-        model_param=model_param, device=device, verbose=verbose,
+        X,
+        betahat,
+        sebetahat,
+        model_class=LcashNet,
+        label="LC-ASH",
+        n_epochs=n_epochs,
+        batch_size=batch_size,
+        lr=lr,
+        weight_decay=weight_decay,
+        penalty=penalty,
+        mult=mult,
+        ash_init=ash_init,
+        ash_threshold=ash_threshold,
+        model_param=model_param,
+        device=device,
+        verbose=verbose,
         seed=seed,
     )
 
@@ -643,11 +661,21 @@ def po_lcash_posterior_means(
         scale (K,), loss, model_param (state dict for warm-starting).
     """
     return _fit_lcash(
-        X, betahat, sebetahat,
-        model_class=PropOddsLcashNet, label="PO-LC-ASH",
-        n_epochs=n_epochs, batch_size=batch_size, lr=lr,
-        weight_decay=weight_decay, penalty=penalty,
-        mult=mult, ash_init=ash_init, ash_threshold=ash_threshold,
-        model_param=model_param, device=device, verbose=verbose,
+        X,
+        betahat,
+        sebetahat,
+        model_class=PropOddsLcashNet,
+        label="PO-LC-ASH",
+        n_epochs=n_epochs,
+        batch_size=batch_size,
+        lr=lr,
+        weight_decay=weight_decay,
+        penalty=penalty,
+        mult=mult,
+        ash_init=ash_init,
+        ash_threshold=ash_threshold,
+        model_param=model_param,
+        device=device,
+        verbose=verbose,
         seed=seed,
     )

--- a/src/cebmf_torch/cebnm/lcash.py
+++ b/src/cebmf_torch/cebnm/lcash.py
@@ -1,0 +1,653 @@
+"""LC-ASH: Linear Covariate Adaptive Shrinkage.
+
+Two parameterisations:
+  - Softmax (multinomial logistic): K independent logit vectors, K*F params.
+  - Proportional odds (ordered logistic): shared weight vector, F+K-1 params.
+
+Both map gene features to mixture weights.  A linear alternative to the
+MLP-based CASH solver, with ash-based bias/cut-point initialisation and
+grid pruning.
+"""
+
+import warnings
+
+import torch
+import torch.nn as nn
+
+from cebmf_torch.cebnm.cash_solver import (
+    cash_PosteriorMeanNorm,
+    pen_loglik_loss,
+)
+from cebmf_torch.ebnm.ash import PriorType, ash
+from cebmf_torch.utils.distribution_operation import get_data_loglik_normal_torch
+from cebmf_torch.utils.mixture import autoselect_scales_mix_norm
+
+
+# ============================================================
+# Model classes
+# ============================================================
+
+
+class LcashNet(nn.Module):
+    """Multinomial logistic regression: features -> mixture weights.
+
+    A single nn.Linear(F, K) followed by softmax. Equivalent to
+    multinomial logistic regression with K classes and F features.
+
+    Parameters
+    ----------
+    input_dim : int
+        Number of input features.
+    num_classes : int
+        Number of mixture components (output classes).
+    log_pi_init : torch.Tensor or None
+        If provided, (K,) tensor of centred log-weights from a global ash
+        fit. Used to initialise the bias so that softmax(bias) approximates
+        the global ash pi when all feature coefficients are zero.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_classes: int,
+        log_pi_init: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ):
+        super().__init__()
+        self.linear = nn.Linear(input_dim, num_classes)
+        # Small random perturbation breaks symmetry across features.
+        # Starting from exact zeros leads Adam to different local
+        # optima on high-dimensional feature sets (F > 100).
+        nn.init.normal_(self.linear.weight, mean=0.0, std=0.01,
+                        generator=generator)
+        if log_pi_init is not None:
+            with torch.no_grad():
+                self.linear.bias.copy_(log_pi_init)
+        else:
+            nn.init.zeros_(self.linear.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.softmax(self.linear(x), dim=1)
+
+
+class PropOddsLcashNet(nn.Module):
+    """Proportional odds (ordered logistic) mapping: features -> mixture weights.
+
+    A single shared weight vector maps features to a scalar signal
+    strength s_i = x_i^T w.  K-1 ordered cut-points convert s_i to
+    mixture weights via cumulative logistic probabilities.
+
+    Parameters
+    ----------
+    input_dim : int
+        Number of input features.
+    num_classes : int
+        Number of mixture components (K).
+    log_pi_init : torch.Tensor or None
+        If provided, (K,) tensor of centred log-weights from a global ash
+        fit.  Used to initialise ordered cut-points so that the model
+        recovers the global ash pi when all feature coefficients are zero.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_classes: int,
+        log_pi_init: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ):
+        super().__init__()
+        K = num_classes
+
+        # Shared feature weights: initialised near zero so the model
+        # starts close to the exchangeable prior.
+        self.w = nn.Parameter(torch.empty(input_dim))
+        nn.init.normal_(self.w, mean=0.0, std=0.01, generator=generator)
+
+        # Cut-point parameterisation: delta_1 (free), delta_2..K-1 (gaps)
+        if log_pi_init is not None and K > 1:
+            init_cuts = self._init_cutpoints_from_pi(log_pi_init, K)
+        else:
+            init_cuts = torch.linspace(-2.0, 2.0, K - 1)
+
+        self.delta_1 = nn.Parameter(init_cuts[0:1])  # (1,)
+        if K > 2:
+            gaps = torch.log(torch.clamp(init_cuts[1:] - init_cuts[:-1], min=1e-6))
+            self.delta_gaps = nn.Parameter(gaps)  # (K-2,)
+        else:
+            self.delta_gaps = None
+
+        self._K = K
+
+    @staticmethod
+    def _init_cutpoints_from_pi(
+        log_pi_init: torch.Tensor, K: int
+    ) -> torch.Tensor:
+        """Initialise cut-points so that sigma(theta_k) approx cumprob_k.
+
+        At initialisation w ~ 0, so s_i ~ 0 for all genes.  Then
+        pi_k = sigma(theta_{k+1}) - sigma(theta_k), so we need
+        sigma(theta_k) = sum_{j<k} pi_j, i.e. theta_k = logit(cumprob_k).
+        """
+        pi = torch.exp(log_pi_init - log_pi_init.max())
+        pi = pi / pi.sum()
+        cumprob = torch.cumsum(pi, dim=0)[:-1]  # K-1 values
+        cumprob = torch.clamp(cumprob, 1e-6, 1 - 1e-6)
+        cuts = torch.log(cumprob / (1 - cumprob))
+        return cuts
+
+    def _get_cutpoints(self) -> torch.Tensor:
+        """Reconstruct ordered cut-points from unconstrained parameters."""
+        # K=1: degenerate case, all weight on the single component.
+        if self._K == 1:
+            return torch.empty(0, device=self.delta_1.device)
+        if self.delta_gaps is not None:
+            gaps = torch.exp(self.delta_gaps)
+            return torch.cat([self.delta_1, self.delta_1 + torch.cumsum(gaps, dim=0)])
+        return self.delta_1  # K = 2: single cut-point
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute mixture weights pi_k for each gene.
+
+        Parameters
+        ----------
+        x : tensor (G, F)
+            Feature matrix.
+
+        Returns
+        -------
+        tensor (G, K)
+            Per-gene mixture weights.
+        """
+        s = x @ self.w  # (G,)
+        theta = self._get_cutpoints()  # (K-1,)
+
+        # Cumulative probabilities: P(category <= k) = sigma(theta_k - s)
+        cum_probs = torch.sigmoid(theta.unsqueeze(0) - s.unsqueeze(1))  # (G, K-1)
+
+        # Convert cumulative to category probabilities
+        ones = torch.ones(s.shape[0], 1, device=x.device)
+        zeros = torch.zeros(s.shape[0], 1, device=x.device)
+        cum_ext = torch.cat([zeros, cum_probs, ones], dim=1)  # (G, K+1)
+        pi = cum_ext[:, 1:] - cum_ext[:, :-1]  # (G, K)
+
+        # Numerical safety: clamp small negatives from floating-point
+        pi = torch.clamp(pi, min=1e-10)
+        pi = pi / pi.sum(dim=1, keepdim=True)
+
+        return pi
+
+
+# ============================================================
+# Shared helpers
+# ============================================================
+
+
+def _prepare_inputs(
+    X: torch.Tensor,
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert inputs to float32 tensors on device and standardise X.
+
+    Uses NaN-aware standardisation: mean and std are computed on
+    non-NaN values only, then NaN positions are zero-filled.  This
+    ensures that missing features contribute nothing to the logits
+    (falling back to the intercept/global prior) and that the
+    statistics are not biased by the zero-fill.
+    """
+    X = torch.as_tensor(X, dtype=torch.float32, device=device)
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    betahat = torch.as_tensor(betahat, dtype=torch.float32, device=device)
+    sebetahat = torch.as_tensor(sebetahat, dtype=torch.float32, device=device)
+    X_scaled = _nanstandardise(X)
+    return X_scaled, betahat, sebetahat
+
+
+def _nanstandardise(X: torch.Tensor) -> torch.Tensor:
+    """Standardise columns using non-NaN values, then zero-fill NaN.
+
+    Vectorised implementation. For each column, compute mean and
+    population std on observed (non-NaN) entries, standardise observed
+    values, and set NaN positions to 0. Columns with zero std
+    (constant or all-NaN) are set to 0.
+    """
+    mask = ~torch.isnan(X)
+    counts = mask.sum(dim=0)  # (F,)
+
+    # Replace NaN with 0 for safe summation
+    X_filled = torch.where(mask, X, torch.zeros_like(X))
+
+    # Mean on observed values
+    safe_counts = counts.clamp(min=1)
+    mu = X_filled.sum(dim=0) / safe_counts  # (F,)
+
+    # Population std on observed values
+    diff = torch.where(mask, X - mu, torch.zeros_like(X))
+    var = (diff ** 2).sum(dim=0) / safe_counts  # (F,)
+    sd = var.sqrt()
+
+    # Standardise observed, zero-fill missing
+    safe_sd = torch.where((sd > 0) & (counts > 1), sd, torch.ones_like(sd))
+    X_out = torch.where(
+        mask & (sd > 0).unsqueeze(0) & (counts > 1).unsqueeze(0),
+        diff / safe_sd,
+        torch.zeros_like(X),
+    )
+    return X_out
+
+
+def _select_grid(
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    mult: float,
+    ash_init: bool,
+    ash_threshold: float,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Select mixture grid and (optionally) initialise from ash.
+
+    Always builds the grid via ``autoselect_scales_mix_norm(mult=mult)``.
+    When ``ash_init=True``, additionally runs a full ash fit (L-BFGS
+    optimizer) to determine which components are active and initialise
+    the bias/cut-points from the ash mixture weights.
+
+    Parameters
+    ----------
+    mult : float
+        Multiplicative step between grid SDs.  Smaller values give a
+        finer grid with more components (sqrt(2) ≈ 27 components,
+        2.0 ≈ 15 components for typical data).
+    ash_init : bool
+        If True, run ash internally with ``optimizer="lbfgs"`` to
+        prune the grid to active components and initialise bias from
+        the ash weights.
+    ash_threshold : float
+        Pruning threshold: components with ``pi <= ash_threshold``
+        are dropped.  Only used when ``ash_init=True``.
+
+    Returns
+    -------
+    scale : tensor (K,)
+        Mixture component standard deviations.
+    log_pi_init : tensor (K,) or None
+        Centred log-weights for bias/cut-point initialisation, or
+        None when ``ash_init=False``.
+    """
+    if ash_init:
+        ash_result = ash(betahat, sebetahat, prior=PriorType.NORM,
+                         verbose=False, optimizer="lbfgs", mult=mult)
+        pi_full = ash_result.pi
+        active = pi_full > ash_threshold
+        # Fallback: ensure at least K=2 (spike + one slab)
+        if active.sum() < 2:
+            active = torch.zeros_like(pi_full, dtype=torch.bool)
+            active[0] = True
+            non_spike = pi_full.clone()
+            non_spike[0] = -1.0
+            active[non_spike.argmax()] = True
+        scale = ash_result.scale[active].to(device=device, dtype=torch.float32)
+        pi_active = pi_full[active]
+        log_pi_init = torch.log(pi_active.clamp(min=1e-30))
+        log_pi_init = log_pi_init - log_pi_init.mean()
+        log_pi_init = log_pi_init.to(device=device, dtype=torch.float32)
+        return scale, log_pi_init
+
+    scale = autoselect_scales_mix_norm(betahat=betahat, sebetahat=sebetahat,
+                                       mult=mult)
+    if not isinstance(scale, torch.Tensor):
+        scale = torch.as_tensor(scale, dtype=torch.float32, device=device)
+    else:
+        scale = scale.to(device=device, dtype=torch.float32)
+    return scale, None
+
+
+def _train_model(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    X_scaled: torch.Tensor,
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    scale: torch.Tensor,
+    n_epochs: int,
+    batch_size: int,
+    penalty: float,
+    verbose: bool,
+    label: str,
+    seed: int = 42,
+) -> float:
+    """Run the training loop. Returns the final-epoch total loss.
+
+    Pre-computes the (G, K) log-likelihood matrix once rather than
+    recomputing per mini-batch (logL is constant during training).
+    Batch ordering is seeded for reproducibility.
+    """
+    model.train()
+    device = X_scaled.device
+
+    # Pre-compute log-likelihood matrix (constant during training).
+    loc = torch.zeros_like(scale)
+    with torch.no_grad():
+        logL_all = get_data_loglik_normal_torch(
+            betahat=betahat, sebetahat=sebetahat,
+            location=loc, scale=scale,
+        )
+
+    # Seeded manual batching (5x faster than DataLoader due to
+    # avoiding per-sample __getitem__ and collation overhead).
+    # Generator and permutation are created on the same device as the
+    # data to avoid CPU/GPU device mismatches.
+    g = torch.Generator(device=device)
+    g.manual_seed(seed)
+    n = X_scaled.shape[0]
+    n_batches = max(1, (n + batch_size - 1) // batch_size)
+
+    final_epoch_loss = 0.0
+    for epoch in range(n_epochs):
+        epoch_loss = 0.0
+        perm = torch.randperm(n, generator=g, device=device)
+        for start in range(0, n, batch_size):
+            idx = perm[start : start + batch_size]
+            pi_pred = model(X_scaled[idx])
+            loss = pen_loglik_loss(pi_pred, logL_all[idx], penalty=penalty)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item()
+        final_epoch_loss = epoch_loss
+        if verbose and (epoch + 1) % 50 == 0:
+            print(f"[{label}] Epoch {epoch + 1}/{n_epochs} | "
+                  f"Loss: {epoch_loss / n_batches:.4f}")
+
+    return final_epoch_loss
+
+
+def _compute_posteriors(
+    model: nn.Module,
+    X_scaled: torch.Tensor,
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    scale: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Vectorised posterior computation with per-observation pi.
+
+    Assumes location = 0 for all mixture components (spike mean is 0).
+    This matches the zero-centred normal mixture prior used by LC-ASH.
+
+    Returns
+    -------
+    post_mean, post_mean2, post_sd, all_pi_values
+    """
+    model.eval()
+    loc = torch.zeros_like(scale)
+    with torch.no_grad():
+        all_pi_values = model(X_scaled)  # (G, K)
+
+        data_loglik = get_data_loglik_normal_torch(
+            betahat=betahat, sebetahat=sebetahat, location=loc, scale=scale
+        )  # (G, K)
+
+        # Use dtype-appropriate eps to avoid log(0) in float32.
+        eps = torch.finfo(all_pi_values.dtype).tiny
+        log_pi_all = torch.log(torch.clamp(all_pi_values, min=eps))  # (G, K)
+        combined = data_loglik + log_pi_all  # (G, K)
+        log_norm = torch.logsumexp(combined, dim=1, keepdim=True)  # (G, 1)
+        resp = torch.exp(combined - log_norm)  # (G, K) responsibilities
+
+        s2 = sebetahat.pow(2).unsqueeze(1)  # (G, 1)
+        t2 = scale.pow(2).unsqueeze(0)  # (1, K)
+
+        denom = (1.0 / s2) + torch.where(t2 > 0, 1.0 / t2, torch.zeros_like(t2))
+        post_var_comp = torch.where(t2 > 0, 1.0 / denom, torch.zeros_like(denom))  # (G, K)
+
+        m_comp = torch.where(
+            t2 > 0,
+            post_var_comp * (betahat.unsqueeze(1) / s2),
+            torch.zeros(1, device=device),
+        )  # (G, K)
+
+        post_mean = torch.sum(resp * m_comp, dim=1)
+        post_mean2 = torch.sum(resp * (post_var_comp + m_comp.pow(2)), dim=1)
+        post_sd = torch.sqrt(torch.clamp(post_mean2 - post_mean.pow(2), min=0.0))
+
+    return post_mean, post_mean2, post_sd, all_pi_values
+
+
+def _warm_start(
+    model: nn.Module,
+    model_param: dict | None,
+    label: str,
+) -> None:
+    """Load state dict with a guard against architecture mismatch."""
+    if model_param is not None:
+        try:
+            model.load_state_dict(model_param)
+        except RuntimeError:
+            warnings.warn(
+                f"{label} warm-start skipped: grid size changed between iterations",
+                stacklevel=3,
+            )
+
+
+def _fit_lcash(
+    X: torch.Tensor,
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    model_class: type,
+    label: str,
+    n_epochs: int = 200,
+    batch_size: int = 512,
+    lr: float = 1e-3,
+    weight_decay: float = 1e-3,
+    penalty: float = 1.5,
+    mult: float = 1.4142135623730951,
+    ash_init: bool = True,
+    ash_threshold: float = 1e-6,
+    model_param: dict | None = None,
+    device: torch.device | None = None,
+    verbose: bool = True,
+    seed: int = 42,
+) -> cash_PosteriorMeanNorm:
+    """Shared implementation for both softmax and proportional odds LC-ASH.
+
+    Parameters
+    ----------
+    model_class : type
+        Either ``LcashNet`` or ``PropOddsLcashNet``.
+    label : str
+        Label for verbose logging (e.g. "LC-ASH" or "PO-LC-ASH").
+
+    See ``lcash_posterior_means`` for other parameter descriptions.
+    """
+    device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if n_epochs is None:
+        n_epochs = 200
+
+    X_scaled, betahat, sebetahat = _prepare_inputs(X, betahat, sebetahat, device)
+    scale, log_pi_init = _select_grid(betahat, sebetahat, mult, ash_init,
+                                       ash_threshold, device)
+
+    # Local RNG for reproducible weight init and batch ordering.
+    # Does not mutate global torch RNG state.
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+
+    K = scale.shape[0]
+    model = model_class(X_scaled.shape[1], K, log_pi_init=log_pi_init,
+                        generator=rng).to(device)
+    _warm_start(model, model_param, label)
+
+    # Build optimizer: weight_decay on feature weights only.
+    if model_class is LcashNet:
+        param_groups = [
+            {"params": [model.linear.weight], "weight_decay": weight_decay},
+            {"params": [model.linear.bias], "weight_decay": 0.0},
+        ]
+    else:  # PropOddsLcashNet
+        cutpoint_params = [model.delta_1]
+        if model.delta_gaps is not None:
+            cutpoint_params.append(model.delta_gaps)
+        param_groups = [
+            {"params": [model.w], "weight_decay": weight_decay},
+            {"params": cutpoint_params, "weight_decay": 0.0},
+        ]
+    optimizer = torch.optim.Adam(param_groups, lr=lr)
+
+    final_loss = _train_model(
+        model, optimizer, X_scaled, betahat, sebetahat, scale,
+        n_epochs, batch_size, penalty, verbose, label, seed=seed,
+    )
+
+    post_mean, post_mean2, post_sd, all_pi_values = _compute_posteriors(
+        model, X_scaled, betahat, sebetahat, scale, device,
+    )
+
+    return cash_PosteriorMeanNorm(
+        post_mean=post_mean,
+        post_mean2=post_mean2,
+        post_sd=post_sd,
+        pi_np=all_pi_values,
+        loss=final_loss,
+        scale=scale,
+        model_param=model.state_dict(),
+    )
+
+
+# ============================================================
+# Public entry points
+# ============================================================
+
+
+def lcash_posterior_means(
+    X: torch.Tensor,
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    n_epochs: int | None = 200,
+    batch_size: int = 512,
+    lr: float = 1e-3,
+    weight_decay: float = 1e-3,
+    penalty: float = 1.5,
+    mult: float = 1.4142135623730951,
+    ash_init: bool = True,
+    ash_threshold: float = 1e-6,
+    model_param: dict | None = None,
+    device: torch.device | None = None,
+    verbose: bool = True,
+    seed: int = 42,
+) -> cash_PosteriorMeanNorm:
+    """LC-ASH: linear covariate-modulated mixture weights.
+
+    Parameters
+    ----------
+    X : tensor (G, F)
+        Feature matrix. Standardised internally with NaN-aware
+        statistics (mean/std computed on non-NaN values, NaN positions
+        zero-filled). Pre-standardisation is not required.
+    betahat : tensor (G,)
+        Effect estimates.
+    sebetahat : tensor (G,)
+        Standard errors.
+    n_epochs : int or None
+        Training epochs. Inside cEBMF, overridden by internal_epoch.
+    batch_size : int
+        Mini-batch size for Adam.
+    lr : float
+        Learning rate.
+    weight_decay : float
+        L2 penalty on feature coefficients only (not bias).
+    penalty : float
+        Dirichlet spike penalty (lambda_pen). 1.0 = no penalty.
+    mult : float
+        Multiplicative step between mixture grid SDs.  Smaller values
+        give a finer grid with more components.  Default sqrt(2)
+        matches R ashr and gives ~27 components before pruning.
+    ash_init : bool
+        If True (default), run ash internally (L-BFGS optimizer) to
+        prune the grid to active components and initialise the bias
+        from the ash weights, so the model starts at the exchangeable
+        ash solution when all feature coefficients are zero.
+        If False, use the full grid with uniform bias initialisation.
+    ash_threshold : float
+        Pruning threshold: components with pi <= threshold are dropped.
+        Only used when ``ash_init=True``.
+    model_param : dict or None
+        State dict from a previous call, for warm-starting.
+    device : torch.device or None
+        Compute device. Defaults to CUDA if available.
+    verbose : bool
+        If True (default), print training progress every 50 epochs.
+    seed : int
+        Random seed for weight initialisation and batch ordering.
+
+    Returns
+    -------
+    cash_PosteriorMeanNorm
+        Container with post_mean, post_mean2, post_sd, pi_np (G, K),
+        scale (K,), loss, model_param (state dict for warm-starting).
+    """
+    return _fit_lcash(
+        X, betahat, sebetahat,
+        model_class=LcashNet, label="LC-ASH",
+        n_epochs=n_epochs, batch_size=batch_size, lr=lr,
+        weight_decay=weight_decay, penalty=penalty,
+        mult=mult, ash_init=ash_init, ash_threshold=ash_threshold,
+        model_param=model_param, device=device, verbose=verbose,
+        seed=seed,
+    )
+
+
+def po_lcash_posterior_means(
+    X: torch.Tensor,
+    betahat: torch.Tensor,
+    sebetahat: torch.Tensor,
+    n_epochs: int | None = 200,
+    batch_size: int = 512,
+    lr: float = 1e-3,
+    weight_decay: float = 1e-3,
+    penalty: float = 1.5,
+    mult: float = 1.4142135623730951,
+    ash_init: bool = True,
+    ash_threshold: float = 1e-6,
+    model_param: dict | None = None,
+    device: torch.device | None = None,
+    verbose: bool = True,
+    seed: int = 42,
+) -> cash_PosteriorMeanNorm:
+    """Proportional odds LC-ASH: ordered logistic covariate-modulated weights.
+
+    A shared weight vector maps features to a scalar signal strength
+    s_i = x_i^T w.  K-1 ordered cut-points convert s_i to mixture
+    weights via cumulative logistic probabilities.  This has F + K - 1
+    parameters (vs K * F for softmax LC-ASH), making it more parsimonious
+    when K is large relative to F.
+
+    When ``ash_init=True``, the grid is pruned to ash's active components
+    and the cut-points are initialised from the ash weights, so the model
+    starts at the exchangeable ash solution.
+
+    Parameters
+    ----------
+    X : tensor (G, F)
+        Feature matrix. Standardised internally with NaN-aware statistics.
+    betahat, sebetahat, n_epochs, batch_size, lr, weight_decay, penalty,
+    mult, ash_init, ash_threshold, model_param, device, verbose, seed :
+        See ``lcash_posterior_means``.
+
+    Returns
+    -------
+    cash_PosteriorMeanNorm
+        Container with post_mean, post_mean2, post_sd, pi_np (G, K),
+        scale (K,), loss, model_param (state dict for warm-starting).
+    """
+    return _fit_lcash(
+        X, betahat, sebetahat,
+        model_class=PropOddsLcashNet, label="PO-LC-ASH",
+        n_epochs=n_epochs, batch_size=batch_size, lr=lr,
+        weight_decay=weight_decay, penalty=penalty,
+        mult=mult, ash_init=ash_init, ash_threshold=ash_threshold,
+        model_param=model_param, device=device, verbose=verbose,
+        seed=seed,
+    )

--- a/src/cebmf_torch/ebnm/ash.py
+++ b/src/cebmf_torch/ebnm/ash.py
@@ -14,6 +14,7 @@ from cebmf_torch.utils.mixture import (
     autoselect_scales_mix_exp,
     autoselect_scales_mix_norm,
     optimize_pi_logL,
+    optimize_pi_logL_lbfgs,
 )
 from cebmf_torch.utils.posterior import (
     PosteriorMean,
@@ -37,18 +38,30 @@ class AshConfig:
     batch_size: int | None = 128
     shuffle: bool = False
     seed: int | None = None
+    optimizer: str = "em"
+
+
+_VALID_OPTIMIZERS = {"em", "lbfgs"}
 
 
 def _optimize_mixture_weights(L: torch.Tensor, config: AshConfig) -> torch.Tensor:
     """Optimize mixture weights and return log probabilities."""
-    pi0 = optimize_pi_logL(
-        L,
-        penalty=config.penalty,
-        verbose=config.verbose,
-        batch_size=config.batch_size,
-        shuffle=config.shuffle,
-        seed=config.seed,
-    )
+    if config.optimizer not in _VALID_OPTIMIZERS:
+        raise ValueError(
+            f"Unknown optimizer {config.optimizer!r}. "
+            f"Choose from {_VALID_OPTIMIZERS}."
+        )
+    if config.optimizer == "lbfgs":
+        pi0 = optimize_pi_logL_lbfgs(L, penalty=config.penalty)
+    elif config.optimizer == "em":
+        pi0 = optimize_pi_logL(
+            L,
+            penalty=config.penalty,
+            verbose=config.verbose,
+            batch_size=config.batch_size,
+            shuffle=config.shuffle,
+            seed=config.seed,
+        )
     eps = torch.tensor(1e-32, device=L.device, dtype=L.dtype)
     return torch.log(torch.clamp(pi0, min=eps.item()))
 
@@ -112,6 +125,7 @@ class ASHResult:
     scale: torch.Tensor
     pi0: torch.Tensor | float
     prior: str
+    pi: torch.Tensor | None = None  # full (K,) mixture weight vector
     log_lik: float = 0.0
     mode: float = 0.0
 
@@ -134,6 +148,7 @@ class ASHResult:
             post_sd=pm_obj.post_sd,
             scale=scale,
             pi0=pi0[0],
+            pi=pi0,
             prior=str(prior),
             log_lik=log_lik,
             mode=float(config.mode),
@@ -155,12 +170,15 @@ def ash(
     batch_size: int | None = 128,
     shuffle: bool = False,
     seed: int | None = None,
+    optimizer: str = "em",
 ):
     """
     Adaptive shrinkage with mixture priors ("norm" or "exp") in pure PyTorch.
 
-    Uses EM for π (mini-batch capable via batch_size).
-    Returns an ASHResult object with Torch tensors.
+    Uses EM for π by default (mini-batch capable via batch_size).
+    Set ``optimizer="lbfgs"`` to use L-BFGS with softmax
+    reparameterisation, which produces sparse solutions matching
+    R ashr's convex optimiser.
 
     Parameters
     ----------
@@ -186,6 +204,9 @@ def ash(
         Whether to shuffle data in EM (default: False).
     seed : int or None, optional
         Random seed for reproducibility.
+    optimizer : str, optional
+        ``"em"`` (default) or ``"lbfgs"``. L-BFGS produces sparse
+        solutions matching R ashr's convex optimiser.
 
     Returns
     -------
@@ -207,5 +228,6 @@ def ash(
         batch_size=batch_size,
         shuffle=shuffle,
         seed=seed,
+        optimizer=optimizer,
     )
     return ASHResult.from_data(torch.as_tensor(x, dtype=x.dtype, device=x.device), s, prior, config)

--- a/src/cebmf_torch/ebnm/ash.py
+++ b/src/cebmf_torch/ebnm/ash.py
@@ -47,10 +47,7 @@ _VALID_OPTIMIZERS = {"em", "lbfgs"}
 def _optimize_mixture_weights(L: torch.Tensor, config: AshConfig) -> torch.Tensor:
     """Optimize mixture weights and return log probabilities."""
     if config.optimizer not in _VALID_OPTIMIZERS:
-        raise ValueError(
-            f"Unknown optimizer {config.optimizer!r}. "
-            f"Choose from {_VALID_OPTIMIZERS}."
-        )
+        raise ValueError(f"Unknown optimizer {config.optimizer!r}. Choose from {_VALID_OPTIMIZERS}.")
     if config.optimizer == "lbfgs":
         pi0 = optimize_pi_logL_lbfgs(L, penalty=config.penalty)
     elif config.optimizer == "em":
@@ -86,7 +83,7 @@ def _ash_exp(
     config: AshConfig,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, PosteriorMean]:
     scale = autoselect_scales_mix_exp(x, s, mult=config.mult)  # (K,) with scale[0]=0 (spike)
-    L =  get_data_loglik_exp_torch(x, s, scale=scale)  # (J,K)
+    L = get_data_loglik_exp_torch(x, s, scale=scale)  # (J,K)
     log_pi0 = _optimize_mixture_weights(L, config)
     pm_obj = posterior_mean_exp(x, s, log_pi=log_pi0, scale=scale)
     return scale, log_pi0, L, pm_obj

--- a/src/cebmf_torch/priors/learned.py
+++ b/src/cebmf_torch/priors/learned.py
@@ -141,7 +141,12 @@ class LearnedBuilder(PriorBuilder):
 
         # A bit annoying that the different types have different ways of handling pi0
         match self.type:
-            case LearnedPriorType.CASH | LearnedPriorType.LCASH | LearnedPriorType.PO_LCASH | LearnedPriorType.SPIKED_EMDN:
+            case (
+                LearnedPriorType.CASH
+                | LearnedPriorType.LCASH
+                | LearnedPriorType.PO_LCASH
+                | LearnedPriorType.SPIKED_EMDN
+            ):
                 # optional: could expose from obj.pi_np
                 pi0_null = obj.pi_np[:, 0]
             case LearnedPriorType.CGB | LearnedPriorType.CGB_SHARP:

--- a/src/cebmf_torch/priors/learned.py
+++ b/src/cebmf_torch/priors/learned.py
@@ -8,6 +8,7 @@ from cebmf_torch.cebnm.cash_solver import cash_posterior_means
 from cebmf_torch.cebnm.cov_gb_prior import cgb_posterior_means
 from cebmf_torch.cebnm.cov_sharp_gb_prior import sharp_cgb_posterior_means
 from cebmf_torch.cebnm.emdn import emdn_posterior_means
+from cebmf_torch.cebnm.lcash import lcash_posterior_means, po_lcash_posterior_means
 from cebmf_torch.cebnm.spiked_emdn import spiked_emdn_posterior_means
 
 from .base import Prior, PriorBuilder
@@ -27,6 +28,10 @@ class LearnedPriorType(StrEnum):
         Covariate sharp Generalized-binary prior.
     EMDN : str
         Empirical Mixture Density Network prior.
+    LCASH : str
+        Linear Covariate Adaptive Shrinkage (softmax / multinomial logistic).
+    PO_LCASH : str
+        Proportional Odds LC-ASH (ordered logistic).
     SPIKED_EMDN : str
         Spiked Empirical Mixture Density Network prior.
     """
@@ -35,6 +40,8 @@ class LearnedPriorType(StrEnum):
     CGB = auto()
     CGB_SHARP = auto()
     EMDN = auto()
+    LCASH = auto()
+    PO_LCASH = auto()
     SPIKED_EMDN = auto()
 
 
@@ -43,6 +50,8 @@ builder_functions: dict[LearnedPriorType, Callable] = {
     LearnedPriorType.CGB: cgb_posterior_means,
     LearnedPriorType.CGB_SHARP: sharp_cgb_posterior_means,
     LearnedPriorType.EMDN: emdn_posterior_means,
+    LearnedPriorType.LCASH: lcash_posterior_means,
+    LearnedPriorType.PO_LCASH: po_lcash_posterior_means,
     LearnedPriorType.SPIKED_EMDN: spiked_emdn_posterior_means,
 }
 
@@ -132,7 +141,7 @@ class LearnedBuilder(PriorBuilder):
 
         # A bit annoying that the different types have different ways of handling pi0
         match self.type:
-            case LearnedPriorType.CASH | LearnedPriorType.SPIKED_EMDN:
+            case LearnedPriorType.CASH | LearnedPriorType.LCASH | LearnedPriorType.PO_LCASH | LearnedPriorType.SPIKED_EMDN:
                 # optional: could expose from obj.pi_np
                 pi0_null = obj.pi_np[:, 0]
             case LearnedPriorType.CGB | LearnedPriorType.CGB_SHARP:

--- a/src/cebmf_torch/utils/__init__.py
+++ b/src/cebmf_torch/utils/__init__.py
@@ -6,7 +6,7 @@ from . import device, distribution_operation, maths, mixture, posterior
 # Most commonly used functions from each module
 from .device import get_device
 from .maths import my_e2truncnorm, my_etruncnorm, safe_tensor_to_float
-from .mixture import autoselect_scales_mix_norm, optimize_pi_logL
+from .mixture import autoselect_scales_mix_norm, optimize_pi_logL, optimize_pi_logL_lbfgs
 from .posterior import posterior_mean_exp, posterior_mean_norm
 
 __all__ = [
@@ -23,6 +23,7 @@ __all__ = [
     "safe_tensor_to_float",
     "autoselect_scales_mix_norm",
     "optimize_pi_logL",
+    "optimize_pi_logL_lbfgs",
     "posterior_mean_exp",
     "posterior_mean_norm",
 ]

--- a/src/cebmf_torch/utils/mixture.py
+++ b/src/cebmf_torch/utils/mixture.py
@@ -233,3 +233,120 @@ def autoselect_scales_mix_exp(
             if scales.numel() >= 3 and scales[2] < torch.tensor(1e-2, device=device, dtype=dtype):
                 scales[2:] = scales[2:] + torch.tensor(1e-2, device=device, dtype=dtype)
     return scales
+
+
+# ============================================================
+# L-BFGS mixture weight optimizer (alternative to EM)
+# ============================================================
+
+@torch.no_grad()
+def optimize_pi_logL_lbfgs(
+    logL: torch.Tensor,
+    penalty: float | torch.Tensor,
+    zero_threshold: float = 1e-6,
+) -> torch.Tensor:
+    """Optimize mixture weights via L-BFGS with softmax reparameterisation.
+
+    An alternative to :func:`optimize_pi_logL` (EM) that produces
+    sparse solutions matching R ashr's convex optimizer (mixsqp) to
+    3-5 significant figures.
+
+    The simplex constraint is eliminated by optimising unconstrained
+    ``z`` where ``x = softmax(z)``.  L-BFGS builds a positive-definite
+    BFGS Hessian approximation from gradient history, avoiding the
+    near-singular exact Hessian that arises from aliased mixture
+    components.
+
+    The Dirichlet penalty is encoded as pseudo-observations following
+    R ashr's convention: the likelihood matrix is augmented with
+    identity rows weighted by ``(alpha_k - 1)``.
+
+    Parameters
+    ----------
+    logL : (n, K) tensor of log-likelihoods.
+    penalty : float or (K,) tensor, Dirichlet pseudo-count.
+    zero_threshold : float
+        Components with weight below this are set to exactly zero.
+        Default 1e-6: a component at this weight contributes at most
+        one-millionth of the mixture density for any observation,
+        which is negligible for posterior computation.  L-BFGS drives
+        inactive components to ~1e-30 via softmax, so any threshold
+        between 1e-10 and 1e-3 gives the same active set.
+
+    Returns
+    -------
+    torch.Tensor
+        (K,) tensor of optimized mixture weights on the simplex.
+    """
+    assert logL.ndim == 2, "logL must be (n, K)"
+    n, K = logL.shape
+    device = logL.device
+    dtype = logL.dtype
+
+    # Penalty vector.
+    if isinstance(penalty, torch.Tensor):
+        vec_pen = penalty.to(device=device, dtype=torch.float64)
+    else:
+        vec_pen = torch.ones(K, device=device, dtype=torch.float64)
+        vec_pen[0] = penalty
+
+    # Convert to likelihood space in float64, row-normalised.
+    logL_f64 = logL.to(torch.float64)
+    row_max = logL_f64.max(dim=1, keepdim=True).values
+    L_data = torch.exp(logL_f64 - row_max)
+
+    # Augment with pseudo-observations for Dirichlet penalty,
+    # matching R ashr: A <- rbind(diag(K), L); w <- c(prior-1, rep(1,n))
+    prior_minus_1 = vec_pen - 1.0
+    pen_idx = torch.where(prior_minus_1 > 0)[0]
+
+    if pen_idx.numel() > 0:
+        I_rows = torch.zeros(pen_idx.numel(), K, device=device,
+                             dtype=torch.float64)
+        for ii, ki in enumerate(pen_idx):
+            I_rows[ii, ki] = 1.0
+        L_aug = torch.cat([I_rows, L_data], dim=0)
+        w_aug = torch.cat([
+            prior_minus_1[pen_idx],
+            torch.ones(n, device=device, dtype=torch.float64),
+        ])
+    else:
+        L_aug = L_data
+        w_aug = torch.ones(n, device=device, dtype=torch.float64)
+
+    w_aug = w_aug / w_aug.sum()
+
+    # Solve via L-BFGS in float64.
+    z = torch.zeros(K, device=device, dtype=torch.float64,
+                    requires_grad=True)
+
+    optimizer = torch.optim.LBFGS(
+        [z], lr=1.0, max_iter=2000,
+        tolerance_grad=1e-8, tolerance_change=1e-10,
+        history_size=10, line_search_fn='strong_wolfe',
+    )
+
+    @torch.no_grad()
+    def closure():
+        z_s = z.data - z.data.max()
+        ex = torch.exp(z_s)
+        x = ex / ex.sum()
+        Lx = (L_aug @ x).clamp(min=1e-300)
+        f = -(w_aug * Lx.log()).sum()
+        dfdx = -(L_aug.T @ (w_aug / Lx))
+        xg = dfdx * x
+        z.grad = xg - x * xg.sum()
+        return f
+
+    optimizer.step(closure)
+
+    with torch.no_grad():
+        z_s = z - z.max()
+        pi = torch.exp(z_s)
+        pi /= pi.sum()
+        pi[pi < zero_threshold] = 0.0
+        s = pi.sum()
+        if s > 0:
+            pi /= s
+
+    return pi.to(dtype)

--- a/src/cebmf_torch/utils/mixture.py
+++ b/src/cebmf_torch/utils/mixture.py
@@ -239,6 +239,7 @@ def autoselect_scales_mix_exp(
 # L-BFGS mixture weight optimizer (alternative to EM)
 # ============================================================
 
+
 @torch.no_grad()
 def optimize_pi_logL_lbfgs(
     logL: torch.Tensor,
@@ -301,15 +302,16 @@ def optimize_pi_logL_lbfgs(
     pen_idx = torch.where(prior_minus_1 > 0)[0]
 
     if pen_idx.numel() > 0:
-        I_rows = torch.zeros(pen_idx.numel(), K, device=device,
-                             dtype=torch.float64)
+        I_rows = torch.zeros(pen_idx.numel(), K, device=device, dtype=torch.float64)
         for ii, ki in enumerate(pen_idx):
             I_rows[ii, ki] = 1.0
         L_aug = torch.cat([I_rows, L_data], dim=0)
-        w_aug = torch.cat([
-            prior_minus_1[pen_idx],
-            torch.ones(n, device=device, dtype=torch.float64),
-        ])
+        w_aug = torch.cat(
+            [
+                prior_minus_1[pen_idx],
+                torch.ones(n, device=device, dtype=torch.float64),
+            ]
+        )
     else:
         L_aug = L_data
         w_aug = torch.ones(n, device=device, dtype=torch.float64)
@@ -317,13 +319,16 @@ def optimize_pi_logL_lbfgs(
     w_aug = w_aug / w_aug.sum()
 
     # Solve via L-BFGS in float64.
-    z = torch.zeros(K, device=device, dtype=torch.float64,
-                    requires_grad=True)
+    z = torch.zeros(K, device=device, dtype=torch.float64, requires_grad=True)
 
     optimizer = torch.optim.LBFGS(
-        [z], lr=1.0, max_iter=2000,
-        tolerance_grad=1e-8, tolerance_change=1e-10,
-        history_size=10, line_search_fn='strong_wolfe',
+        [z],
+        lr=1.0,
+        max_iter=2000,
+        tolerance_grad=1e-8,
+        tolerance_change=1e-10,
+        history_size=10,
+        line_search_fn="strong_wolfe",
     )
 
     @torch.no_grad()

--- a/tests/test_lcash_posterior.py
+++ b/tests/test_lcash_posterior.py
@@ -1,0 +1,247 @@
+import pytest
+import torch
+
+from cebmf_torch.cebnm.lcash import lcash_posterior_means, po_lcash_posterior_means
+
+
+@pytest.mark.parametrize("n_samples", [1000])
+def test_lcash_posterior_means_mse_autoselect(n_samples):
+    """LC-ASH with auto-selected grid should shrink on linearly-separable data."""
+    torch.manual_seed(1)
+
+    # Linearly-separable signal: high covariate -> large effect, low -> near zero
+    y = torch.randn(n_samples)
+    X = y.view(-1, 1)
+
+    # Signal strength scales linearly with covariate
+    signal_sd = torch.clamp(y, min=0.0)  # only positive y has signal
+    xtrue = torch.randn(n_samples) * signal_sd
+
+    x = xtrue + torch.randn_like(xtrue)  # betahat = true + noise
+    s = torch.ones_like(x)  # se = 1
+
+    res = lcash_posterior_means(
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=100,
+        batch_size=256,
+        lr=1e-3,
+        penalty=1.5,
+        ash_init=False,
+    )
+
+    mse = torch.mean((res.post_mean - xtrue).pow(2)).item()
+    # Baseline: no shrinkage MSE ~ 1.0 (noise variance)
+    # Good shrinkage should reduce this below 0.7
+    print(f"LC-ASH (auto-select) MSE: {mse:.4f}")
+    assert mse < 0.7, f"MSE too large: {mse}"
+    assert res.model_param is not None
+    assert res.pi_np.shape == (n_samples, res.scale.shape[0])
+
+
+@pytest.mark.parametrize("n_samples", [1000])
+def test_lcash_posterior_means_mse_inherit(n_samples):
+    """LC-ASH with inherited grid should shrink and produce fewer components."""
+    torch.manual_seed(1)
+
+    y = torch.randn(n_samples)
+    X = y.view(-1, 1)
+    signal_sd = torch.clamp(y, min=0.0)
+    xtrue = torch.randn(n_samples) * signal_sd
+
+    x = xtrue + torch.randn_like(xtrue)
+    s = torch.ones_like(x)
+
+    res = lcash_posterior_means(
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=100,
+        batch_size=256,
+        lr=1e-3,
+        penalty=1.5,
+        ash_init=True,
+        ash_threshold=0.0,
+    )
+
+    mse = torch.mean((res.post_mean - xtrue).pow(2)).item()
+    print(f"LC-ASH (inherit grid) MSE: {mse:.4f}")
+    assert mse < 0.7, f"MSE too large: {mse}"
+    K = res.scale.shape[0]
+    print(f"LC-ASH (inherit grid) K={K}")
+    assert K < 20, f"Expected pruned grid with K < 20, got K={K}"
+
+
+def test_lcash_warm_start():
+    """Warm-starting from a previous model_param should work."""
+    torch.manual_seed(42)
+    n = 5000
+    y = torch.randn(n)
+    X = y.view(-1, 1)
+    x = y + 0.5 * torch.randn(n)
+    s = 0.5 * torch.ones(n)
+
+    res1 = lcash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=20, ash_init=False,
+    )
+
+    res2 = lcash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=20, ash_init=False,
+        model_param=res1.model_param,
+    )
+
+    assert res2.model_param is not None
+    mse1 = torch.mean((res1.post_mean - y).pow(2)).item()
+    mse2 = torch.mean((res2.post_mean - y).pow(2)).item()
+    print(f"Cold-start MSE: {mse1:.4f}, Warm-start MSE: {mse2:.4f}")
+    assert mse2 < mse1 + 0.05, "Warm-start should not degrade substantially"
+
+
+def test_lcash_ash_result_pi_field():
+    """ASHResult should now have a pi field with the full weight vector."""
+    from cebmf_torch.ebnm.ash import PriorType, ash
+
+    torch.manual_seed(1)
+    x = torch.randn(1000)
+    s = torch.ones(1000)
+
+    result = ash(x, s, prior=PriorType.NORM, verbose=False)
+    assert hasattr(result, "pi"), "ASHResult should have a 'pi' field"
+    assert result.pi.shape == result.scale.shape, "pi should have same shape as scale"
+    assert abs(result.pi.sum().item() - 1.0) < 1e-5, "pi should sum to 1"
+    assert abs(result.pi[0].item() - result.pi0) < 1e-5, "pi[0] should equal pi0"
+
+
+# ---- Proportional Odds LC-ASH tests ----
+
+
+@pytest.mark.parametrize("n_samples", [1000])
+def test_po_lcash_posterior_means_mse_autoselect(n_samples):
+    """PO-LC-ASH with auto-selected grid should shrink on linearly-separable data."""
+    torch.manual_seed(1)
+
+    y = torch.randn(n_samples)
+    X = y.view(-1, 1)
+    signal_sd = torch.clamp(y, min=0.0)
+    xtrue = torch.randn(n_samples) * signal_sd
+
+    x = xtrue + torch.randn_like(xtrue)
+    s = torch.ones_like(x)
+
+    res = po_lcash_posterior_means(
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=100,
+        batch_size=256,
+        lr=1e-3,
+        penalty=1.5,
+        ash_init=False,
+    )
+
+    mse = torch.mean((res.post_mean - xtrue).pow(2)).item()
+    print(f"PO-LC-ASH (auto-select) MSE: {mse:.4f}")
+    assert mse < 0.7, f"MSE too large: {mse}"
+    assert res.model_param is not None
+    assert res.pi_np.shape == (n_samples, res.scale.shape[0])
+
+
+@pytest.mark.parametrize("n_samples", [1000])
+def test_po_lcash_posterior_means_mse_inherit(n_samples):
+    """PO-LC-ASH with inherited grid should shrink and produce fewer components."""
+    torch.manual_seed(1)
+
+    y = torch.randn(n_samples)
+    X = y.view(-1, 1)
+    signal_sd = torch.clamp(y, min=0.0)
+    xtrue = torch.randn(n_samples) * signal_sd
+
+    x = xtrue + torch.randn_like(xtrue)
+    s = torch.ones_like(x)
+
+    res = po_lcash_posterior_means(
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=100,
+        batch_size=256,
+        lr=1e-3,
+        penalty=1.5,
+        ash_init=True,
+        ash_threshold=0.0,
+    )
+
+    mse = torch.mean((res.post_mean - xtrue).pow(2)).item()
+    print(f"PO-LC-ASH (inherit grid) MSE: {mse:.4f}")
+    assert mse < 0.7, f"MSE too large: {mse}"
+    K = res.scale.shape[0]
+    print(f"PO-LC-ASH (inherit grid) K={K}")
+    assert K < 20, f"Expected pruned grid with K < 20, got K={K}"
+
+
+def test_po_lcash_warm_start():
+    """Warm-starting PO-LC-ASH from a previous model_param should work."""
+    torch.manual_seed(42)
+    n = 5000
+    y = torch.randn(n)
+    X = y.view(-1, 1)
+    x = y + 0.5 * torch.randn(n)
+    s = 0.5 * torch.ones(n)
+
+    res1 = po_lcash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=20, ash_init=False,
+    )
+
+    res2 = po_lcash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=20, ash_init=False,
+        model_param=res1.model_param,
+    )
+
+    assert res2.model_param is not None
+    mse1 = torch.mean((res1.post_mean - y).pow(2)).item()
+    mse2 = torch.mean((res2.post_mean - y).pow(2)).item()
+    print(f"PO cold-start MSE: {mse1:.4f}, PO warm-start MSE: {mse2:.4f}")
+    assert mse2 < mse1 + 0.05, "Warm-start should not degrade substantially"
+
+
+def test_po_lcash_k2_edge_case():
+    """PO-LC-ASH should work with K=2 (single cut-point, no delta_gaps)."""
+    from cebmf_torch.cebnm.lcash import PropOddsLcashNet
+
+    torch.manual_seed(1)
+    F, K = 3, 2
+    model = PropOddsLcashNet(F, K)
+
+    # delta_gaps should be None for K=2
+    assert model.delta_gaps is None, "K=2 should have no delta_gaps"
+
+    # Forward pass should produce valid probabilities
+    x = torch.randn(100, F)
+    pi = model(x)
+    assert pi.shape == (100, 2)
+    assert torch.allclose(pi.sum(dim=1), torch.ones(100), atol=1e-5)
+    assert (pi > 0).all(), "All probabilities should be positive"
+
+
+def test_po_lcash_fewer_params_than_softmax():
+    """PO-LC-ASH should have fewer parameters than softmax LC-ASH."""
+    from cebmf_torch.cebnm.lcash import LcashNet, PropOddsLcashNet
+
+    F, K = 10, 20
+    softmax = LcashNet(F, K)
+    propodds = PropOddsLcashNet(F, K)
+
+    n_softmax = sum(p.numel() for p in softmax.parameters())
+    n_propodds = sum(p.numel() for p in propodds.parameters())
+
+    print(f"Softmax params: {n_softmax}, PropOdds params: {n_propodds}")
+    # Softmax: F*K + K = 10*20 + 20 = 220
+    # PropOdds: F + 1 + (K-2) = 10 + 1 + 18 = 29
+    assert n_propodds < n_softmax, (
+        f"PropOdds ({n_propodds}) should have fewer params than Softmax ({n_softmax})"
+    )

--- a/tests/test_lcash_posterior.py
+++ b/tests/test_lcash_posterior.py
@@ -83,13 +83,19 @@ def test_lcash_warm_start():
     s = 0.5 * torch.ones(n)
 
     res1 = lcash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=20, ash_init=False,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=20,
+        ash_init=False,
     )
 
     res2 = lcash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=20, ash_init=False,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=20,
+        ash_init=False,
         model_param=res1.model_param,
     )
 
@@ -192,13 +198,19 @@ def test_po_lcash_warm_start():
     s = 0.5 * torch.ones(n)
 
     res1 = po_lcash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=20, ash_init=False,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=20,
+        ash_init=False,
     )
 
     res2 = po_lcash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=20, ash_init=False,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=20,
+        ash_init=False,
         model_param=res1.model_param,
     )
 
@@ -242,6 +254,4 @@ def test_po_lcash_fewer_params_than_softmax():
     print(f"Softmax params: {n_softmax}, PropOdds params: {n_propodds}")
     # Softmax: F*K + K = 10*20 + 20 = 220
     # PropOdds: F + 1 + (K-2) = 10 + 1 + 18 = 29
-    assert n_propodds < n_softmax, (
-        f"PropOdds ({n_propodds}) should have fewer params than Softmax ({n_softmax})"
-    )
+    assert n_propodds < n_softmax, f"PropOdds ({n_propodds}) should have fewer params than Softmax ({n_softmax})"

--- a/tests/test_mixture_optimizer.py
+++ b/tests/test_mixture_optimizer.py
@@ -4,8 +4,8 @@ import math
 
 import torch
 
-from cebmf_torch.utils.mixture import autoselect_scales_mix_norm, optimize_pi_logL, optimize_pi_logL_lbfgs
 from cebmf_torch.utils.distribution_operation import get_data_loglik_normal_torch
+from cebmf_torch.utils.mixture import autoselect_scales_mix_norm, optimize_pi_logL, optimize_pi_logL_lbfgs
 
 
 def _penalised_ll(pi, logL, penalty=10.0):
@@ -29,7 +29,10 @@ def test_lbfgs_produces_sparse_solution():
     se = torch.ones(5000)
     scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
     logL = get_data_loglik_normal_torch(
-        betahat, se, torch.zeros_like(scale), scale,
+        betahat,
+        se,
+        torch.zeros_like(scale),
+        scale,
     )
 
     pi_em = optimize_pi_logL(logL, penalty=10.0, verbose=False)
@@ -38,9 +41,7 @@ def test_lbfgs_produces_sparse_solution():
     # Compare at the same threshold: components > 1e-6
     n_em = (pi_em > 1e-6).sum().item()
     n_lbfgs = (pi_lbfgs > 1e-6).sum().item()
-    assert n_lbfgs < n_em, (
-        f"L-BFGS ({n_lbfgs}) should have fewer active than EM ({n_em})"
-    )
+    assert n_lbfgs < n_em, f"L-BFGS ({n_lbfgs}) should have fewer active than EM ({n_em})"
 
 
 def test_lbfgs_simplex_constraint():
@@ -50,7 +51,10 @@ def test_lbfgs_simplex_constraint():
     se = torch.ones(500) * 0.5
     scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
     logL = get_data_loglik_normal_torch(
-        betahat, se, torch.zeros_like(scale), scale,
+        betahat,
+        se,
+        torch.zeros_like(scale),
+        scale,
     )
 
     pi = optimize_pi_logL_lbfgs(logL, penalty=10.0)
@@ -65,7 +69,10 @@ def test_optimizer_em_is_deterministic():
     se = torch.ones(500)
     scale = autoselect_scales_mix_norm(betahat, se)
     logL = get_data_loglik_normal_torch(
-        betahat, se, torch.zeros_like(scale), scale,
+        betahat,
+        se,
+        torch.zeros_like(scale),
+        scale,
     )
 
     pi_a = optimize_pi_logL(logL, penalty=10.0, verbose=False)
@@ -81,7 +88,10 @@ def test_lbfgs_spike_dominated():
     se = torch.ones(1000)
     scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
     logL = get_data_loglik_normal_torch(
-        betahat, se, torch.zeros_like(scale), scale,
+        betahat,
+        se,
+        torch.zeros_like(scale),
+        scale,
     )
 
     pi = optimize_pi_logL_lbfgs(logL, penalty=10.0)
@@ -111,7 +121,10 @@ def test_lbfgs_vs_em_spike_dominated():
 
     scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
     logL = get_data_loglik_normal_torch(
-        betahat, se, torch.zeros_like(scale), scale,
+        betahat,
+        se,
+        torch.zeros_like(scale),
+        scale,
     )
 
     # Pure EM
@@ -122,21 +135,12 @@ def test_lbfgs_vs_em_spike_dominated():
     # L-BFGS should be sparser
     n_active_em = (pi_em > 1e-6).sum().item()
     n_active_lbfgs = (pi_lbfgs > 0).sum().item()
-    assert n_active_lbfgs < n_active_em, (
-        f"L-BFGS ({n_active_lbfgs}) should have fewer active than "
-        f"EM ({n_active_em})"
-    )
+    assert n_active_lbfgs < n_active_em, f"L-BFGS ({n_active_lbfgs}) should have fewer active than EM ({n_active_em})"
 
     # L-BFGS should have higher spike weight
-    assert pi_lbfgs[0] > pi_em[0] + 0.01, (
-        f"L-BFGS spike ({pi_lbfgs[0]:.4f}) should exceed "
-        f"EM spike ({pi_em[0]:.4f})"
-    )
+    assert pi_lbfgs[0] > pi_em[0] + 0.01, f"L-BFGS spike ({pi_lbfgs[0]:.4f}) should exceed EM spike ({pi_em[0]:.4f})"
 
     # L-BFGS should achieve higher penalised log-likelihood
     obj_em = _penalised_ll(pi_em, logL)
     obj_lbfgs = _penalised_ll(pi_lbfgs, logL)
-    assert obj_lbfgs > obj_em, (
-        f"L-BFGS objective ({obj_lbfgs:.2f}) should exceed "
-        f"EM objective ({obj_em:.2f})"
-    )
+    assert obj_lbfgs > obj_em, f"L-BFGS objective ({obj_lbfgs:.2f}) should exceed EM objective ({obj_em:.2f})"

--- a/tests/test_mixture_optimizer.py
+++ b/tests/test_mixture_optimizer.py
@@ -1,0 +1,142 @@
+"""Tests for the mixture weight optimizer (L-BFGS + softmax)."""
+
+import math
+
+import torch
+
+from cebmf_torch.utils.mixture import autoselect_scales_mix_norm, optimize_pi_logL, optimize_pi_logL_lbfgs
+from cebmf_torch.utils.distribution_operation import get_data_loglik_normal_torch
+
+
+def _penalised_ll(pi, logL, penalty=10.0):
+    """Compute penalised log-likelihood."""
+    K = logL.shape[1]
+    vec_pen = torch.ones(K, dtype=pi.dtype)
+    vec_pen[0] = penalty
+    active = pi > 0
+    pi_a = pi[active]
+    log_pi = torch.log(pi_a)
+    log_mix = logL[:, active] + log_pi.unsqueeze(0)
+    ll = torch.logsumexp(log_mix, dim=1).sum()
+    ll += ((vec_pen[active] - 1.0) * log_pi).sum()
+    return ll.item()
+
+
+def test_lbfgs_produces_sparse_solution():
+    """L-BFGS should produce fewer active components than pure EM."""
+    torch.manual_seed(42)
+    betahat = torch.randn(5000)
+    se = torch.ones(5000)
+    scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
+    logL = get_data_loglik_normal_torch(
+        betahat, se, torch.zeros_like(scale), scale,
+    )
+
+    pi_em = optimize_pi_logL(logL, penalty=10.0, verbose=False)
+    pi_lbfgs = optimize_pi_logL_lbfgs(logL, penalty=10.0)
+
+    # Compare at the same threshold: components > 1e-6
+    n_em = (pi_em > 1e-6).sum().item()
+    n_lbfgs = (pi_lbfgs > 1e-6).sum().item()
+    assert n_lbfgs < n_em, (
+        f"L-BFGS ({n_lbfgs}) should have fewer active than EM ({n_em})"
+    )
+
+
+def test_lbfgs_simplex_constraint():
+    """L-BFGS result should be on the simplex."""
+    torch.manual_seed(7)
+    betahat = torch.randn(500)
+    se = torch.ones(500) * 0.5
+    scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
+    logL = get_data_loglik_normal_torch(
+        betahat, se, torch.zeros_like(scale), scale,
+    )
+
+    pi = optimize_pi_logL_lbfgs(logL, penalty=10.0)
+    assert (pi >= 0).all(), "All weights must be >= 0"
+    assert abs(pi.sum().item() - 1.0) < 1e-6
+
+
+def test_optimizer_em_is_deterministic():
+    """With EM, results are deterministic and have no exact zeros."""
+    torch.manual_seed(1)
+    betahat = torch.randn(500)
+    se = torch.ones(500)
+    scale = autoselect_scales_mix_norm(betahat, se)
+    logL = get_data_loglik_normal_torch(
+        betahat, se, torch.zeros_like(scale), scale,
+    )
+
+    pi_a = optimize_pi_logL(logL, penalty=10.0, verbose=False)
+    pi_b = optimize_pi_logL(logL, penalty=10.0, verbose=False)
+    assert torch.allclose(pi_a, pi_b, atol=1e-10)
+    assert (pi_a > 0).all(), "Pure EM should not produce exact zeros"
+
+
+def test_lbfgs_spike_dominated():
+    """On pure-noise data, the spike should dominate."""
+    torch.manual_seed(123)
+    betahat = torch.randn(1000)
+    se = torch.ones(1000)
+    scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
+    logL = get_data_loglik_normal_torch(
+        betahat, se, torch.zeros_like(scale), scale,
+    )
+
+    pi = optimize_pi_logL_lbfgs(logL, penalty=10.0)
+    assert pi[0] > 0.5, f"Spike should dominate, got {pi[0]:.4f}"
+    assert pi[0] == pi.max()
+
+
+def test_lbfgs_vs_em_spike_dominated():
+    """On spike-dominated data, L-BFGS finds the sparse solution that EM misses.
+
+    EM spreads mass across aliased near-spike components because it
+    structurally cannot produce exact zeros.  L-BFGS with softmax
+    drives aliases to zero via the BFGS Hessian approximation,
+    producing a sparser solution with higher penalised log-likelihood.
+    """
+    torch.manual_seed(42)
+    n = 10000
+    se = 0.1 * torch.ones(n)
+
+    # 95% null, 5% signal from N(0, 0.04)
+    n_null = int(0.95 * n)
+    beta_null = torch.randn(n_null) * se[:n_null]
+    theta = torch.randn(n - n_null) * 0.2
+    beta_signal = theta + torch.randn(n - n_null) * se[n_null:]
+    betahat = torch.cat([beta_null, beta_signal])
+    betahat = betahat[torch.randperm(n)]
+
+    scale = autoselect_scales_mix_norm(betahat, se, mult=math.sqrt(2))
+    logL = get_data_loglik_normal_torch(
+        betahat, se, torch.zeros_like(scale), scale,
+    )
+
+    # Pure EM
+    pi_em = optimize_pi_logL(logL, penalty=10.0, verbose=False)
+    # L-BFGS
+    pi_lbfgs = optimize_pi_logL_lbfgs(logL, penalty=10.0)
+
+    # L-BFGS should be sparser
+    n_active_em = (pi_em > 1e-6).sum().item()
+    n_active_lbfgs = (pi_lbfgs > 0).sum().item()
+    assert n_active_lbfgs < n_active_em, (
+        f"L-BFGS ({n_active_lbfgs}) should have fewer active than "
+        f"EM ({n_active_em})"
+    )
+
+    # L-BFGS should have higher spike weight
+    assert pi_lbfgs[0] > pi_em[0] + 0.01, (
+        f"L-BFGS spike ({pi_lbfgs[0]:.4f}) should exceed "
+        f"EM spike ({pi_em[0]:.4f})"
+    )
+
+    # L-BFGS should achieve higher penalised log-likelihood
+    obj_em = _penalised_ll(pi_em, logL)
+    obj_lbfgs = _penalised_ll(pi_lbfgs, logL)
+    assert obj_lbfgs > obj_em, (
+        f"L-BFGS objective ({obj_lbfgs:.2f}) should exceed "
+        f"EM objective ({obj_em:.2f})"
+    )


### PR DESCRIPTION
Refs #57

# Add LC-ASH and PO-LC-ASH solvers: linear covariate-modulated mixture weights

## Summary

This PR adds two linear covariate-modulated cEBNM solvers and an opt-in
L-BFGS mixture-weight optimizer:

- adds `LcashNet`: softmax / multinomial-logistic LC-ASH
- adds `PropOddsLcashNet`: proportional-odds LC-ASH with `F + K - 1`
  parameters instead of `K * F`
- adds `optimize_pi_logL_lbfgs()` as an alternative to EM for ash-style
  mixture-weight fitting (`optimizer="lbfgs"`; EM remains the default)
- exposes the full ash mixture vector on `ASHResult` as `pi`
- registers `prior_L="lcash"` and `prior_L="po_lcash"`

For design rationale, scope, and discussion, see issue #57.

## Motivation

The existing covariate solvers are all more flexible than necessary for
some problems:
- CASH: MLP
- CGB: gradient-boosted
- EMDN: neural

When the relationship between covariates and mixture weights is close to
linear, these models can overfit. LC-ASH and PO-LC-ASH provide simpler
alternatives that sit between exchangeable ash and CASH:

```text
ash -> PO-LC-ASH -> LC-ASH -> CASH -> EMDN
```

This PR also adds an L-BFGS mixture-weight optimizer for ash-style
fitting. It is used by the `ash_init=True` path to get sparse active-set
selection that matches R `ashr` much more closely than the existing EM
solver at default iteration counts.

## Main changes

### 1. New linear solvers

New file:
- `src/cebmf_torch/cebnm/lcash.py`

Adds:
- `lcash_posterior_means()`
- `po_lcash_posterior_means()`

Both:
- standardize covariates internally,
- support `ash_init=True` grid pruning / initialization,
- support warm-starting via `model_param`,
- return `cash_PosteriorMeanNorm`-style outputs for integration with
  existing learned-prior machinery.

### 2. Opt-in L-BFGS mixture optimizer

Modified:
- `src/cebmf_torch/utils/mixture.py`
- `src/cebmf_torch/ebnm/ash.py`
- `src/cebmf_torch/utils/__init__.py`

Adds:
- `optimize_pi_logL_lbfgs()`
- `optimizer` option on `ash()` / `AshConfig`

Default behaviour is unchanged:
- `optimizer="em"` remains the default
- existing ash tests should continue to behave as before

### 3. Registry/API integration

Modified:
- `src/cebmf_torch/priors/learned.py`
- `src/cebmf_torch/cebnm/__init__.py`

Adds support for:
- `prior_L="lcash"`
- `prior_L="po_lcash"`

### 4. Tests

New tests cover:
- L-BFGS simplex/sparsity behaviour
- LC-ASH and PO-LC-ASH shrinkage on synthetic data
- warm-starting
- `ASHResult.pi` exposure
- proportional-odds edge cases / parameter-count sanity check

## Compatibility

- EM remains the default optimizer in `ash()`
- `cash_solver.py` is unchanged
- registry plumbing remains automatic via `LearnedPriorType`
- existing code that uses `result.pi0` continues to work in current
  in-repo usage; the new `ASHResult.pi` field is added for
  `ash_init=True`

## Usage

```python
from cebmf_torch.cebmf import cEBMF

# Softmax LC-ASH
model = cEBMF(data, prior_L="lcash",
              prior_L_kwargs={"ash_init": True})

# Proportional-odds LC-ASH
model = cEBMF(data, prior_L="po_lcash",
              prior_L_kwargs={"ash_init": True})
```

To use the new ash optimizer directly:

```python
from cebmf_torch.ebnm.ash import PriorType, ash

res = ash(x, s, prior=PriorType.NORM, optimizer="lbfgs")
```

## Verification

Current test set for this change:
- `tests/test_mixture_optimizer.py` (5 tests)
- `tests/test_lcash_posterior.py` (9 tests)
- plus existing ash posterior tests

For fuller rationale and design discussion, see issue #57.
