### PR TITLE
Return proper marginal log-likelihood in CASH and LC-ASH `result.loss`

### DIFF
--- a/src/cebmf_torch/cebnm/cash_solver.py
+++ b/src/cebmf_torch/cebnm/cash_solver.py
@@ -200,7 +200,6 @@ def cash_posterior_means(
     optimizer_cash = optim.Adam(model_cash.parameters(), lr=lr)
 
     # ---- training
-    total_cash_loss = 0.0
     for epoch in range(n_epochs):
         epoch_loss = 0.0
         for inputs, targets, noise_std in dataloader:
@@ -215,7 +214,6 @@ def cash_posterior_means(
             optimizer_cash.step()
             epoch_loss += cash_loss.item()
 
-        total_cash_loss = epoch_loss
         if (epoch + 1) % 10 == 0:
             print(f"[CASH] Epoch {epoch + 1}/{n_epochs} | Loss: {epoch_loss / max(1, len(dataloader)):.4f}")
 
@@ -250,17 +248,22 @@ def cash_posterior_means(
             post_mean[i] = res_i.post_mean
             post_mean2[i] = res_i.post_mean2
             post_sd[i] = res_i.post_sd
-     # ---- compute proper full negative marginal log-likelihood (no penalty)
- 
- # ---- compute proper full negative marginal log-likelihood (no penalty)
- 
+
+        # ---- proper full negative marginal log-likelihood (no penalty).
+        # Computed in log space via logsumexp (no `clamp(min=1e-10)` floor on
+        # the inner density). This is what `cebmf.py:299`'s `kl_l[k] = (-loss)
+        # - nm_ll_L` formula expects, and matches the `cebnm/emdn.py:288-298`
+        # convention.
+        log_pi_full = torch.log(all_pi_values.clamp_min(eps))           # (N, K)
+        log_marginal_per_obs = torch.logsumexp(data_loglik + log_pi_full, dim=1)  # (N,)
+        full_marginal_ll = float(log_marginal_per_obs.sum().item())
 
     return cash_PosteriorMeanNorm(
         post_mean=post_mean,
         post_mean2=post_mean2,
-        post_sd=post_sd, 
+        post_sd=post_sd,
         pi_np=all_pi_values,  # (N, K) on device
-        loss= total_cash_loss,
+        loss=-full_marginal_ll,
         scale=scale,  # (K,) on device
         model_param=model_cash.state_dict(),
     )

--- a/src/cebmf_torch/cebnm/cash_solver.py
+++ b/src/cebmf_torch/cebnm/cash_solver.py
@@ -254,7 +254,7 @@ def cash_posterior_means(
         # the inner density). This is what `cebmf.py:299`'s `kl_l[k] = (-loss)
         # - nm_ll_L` formula expects, and matches the `cebnm/emdn.py:288-298`
         # convention.
-        log_pi_full = torch.log(all_pi_values.clamp_min(eps))           # (N, K)
+        log_pi_full = torch.log(all_pi_values.clamp_min(eps))  # (N, K)
         log_marginal_per_obs = torch.logsumexp(data_loglik + log_pi_full, dim=1)  # (N,)
         full_marginal_ll = float(log_marginal_per_obs.sum().item())
 

--- a/src/cebmf_torch/cebnm/lcash.py
+++ b/src/cebmf_torch/cebnm/lcash.py
@@ -366,7 +366,7 @@ def _compute_posteriors(
     sebetahat: torch.Tensor,
     scale: torch.Tensor,
     device: torch.device,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, float]:
     """Vectorised posterior computation with per-observation pi.
 
     Assumes location = 0 for all mixture components (spike mean is 0).
@@ -374,7 +374,13 @@ def _compute_posteriors(
 
     Returns
     -------
-    post_mean, post_mean2, post_sd, all_pi_values
+    post_mean, post_mean2, post_sd, all_pi_values, marginal_loglik
+        ``marginal_loglik`` is the full-data marginal log-likelihood
+        ``sum_g logsumexp_k (log pi_g,k + log p(beta_g | 0, sqrt(se_g^2 + scale_k^2)))``,
+        i.e. ``log p(y | fitted prior)`` without any spike Dirichlet penalty.
+        It is what the cebmf consumer at ``cebmf.py:299``
+        (``self.kl_l[k] = (-resL.loss) - nm_ll_L``) requires of the loss
+        field on this object.
     """
     model.eval()
     loc = torch.zeros_like(scale)
@@ -390,6 +396,9 @@ def _compute_posteriors(
         log_pi_all = torch.log(torch.clamp(all_pi_values, min=eps))  # (G, K)
         combined = data_loglik + log_pi_all  # (G, K)
         log_norm = torch.logsumexp(combined, dim=1, keepdim=True)  # (G, 1)
+        # log_norm[g] is the per-gene marginal log-likelihood of the fitted
+        # mixture; summing gives the full-data marginal log-lik (no penalty).
+        marginal_loglik = float(log_norm.sum().item())
         resp = torch.exp(combined - log_norm)  # (G, K) responsibilities
 
         s2 = sebetahat.pow(2).unsqueeze(1)  # (G, 1)
@@ -408,7 +417,7 @@ def _compute_posteriors(
         post_mean2 = torch.sum(resp * (post_var_comp + m_comp.pow(2)), dim=1)
         post_sd = torch.sqrt(torch.clamp(post_mean2 - post_mean.pow(2), min=0.0))
 
-    return post_mean, post_mean2, post_sd, all_pi_values
+    return post_mean, post_mean2, post_sd, all_pi_values, marginal_loglik
 
 
 def _warm_start(
@@ -489,7 +498,7 @@ def _fit_lcash(
         ]
     optimizer = torch.optim.Adam(param_groups, lr=lr)
 
-    final_loss = _train_model(
+    _train_model(
         model,
         optimizer,
         X_scaled,
@@ -504,7 +513,7 @@ def _fit_lcash(
         seed=seed,
     )
 
-    post_mean, post_mean2, post_sd, all_pi_values = _compute_posteriors(
+    post_mean, post_mean2, post_sd, all_pi_values, marginal_loglik = _compute_posteriors(
         model,
         X_scaled,
         betahat,
@@ -513,12 +522,20 @@ def _fit_lcash(
         device,
     )
 
+    # `loss` is the negative full-data marginal log-likelihood under the
+    # fitted prior, *without* the spike Dirichlet penalty. This matches
+    # the convention used by `cebnm/emdn.py` and is the meaning required
+    # by `cebmf.py`'s per-factor `kl_l[k] = (-loss) - nm_ll_L` formula.
+    # The previous training-loss-on-final-epoch return value was an
+    # unfinished refactor (cf. the `# compute proper full negative
+    # marginal log-likelihood (no penalty)` TODO comments that used to
+    # live in `cash_solver.py`).
     return cash_PosteriorMeanNorm(
         post_mean=post_mean,
         post_mean2=post_mean2,
         post_sd=post_sd,
         pi_np=all_pi_values,
-        loss=final_loss,
+        loss=-marginal_loglik,
         scale=scale,
         model_param=model.state_dict(),
     )

--- a/tests/test_lcash_loss_is_marginal_loglik.py
+++ b/tests/test_lcash_loss_is_marginal_loglik.py
@@ -11,11 +11,11 @@ density at ``1e-10``. After the fix it is computed via a single full-batch
 ``logsumexp`` over the saved per-observation pi values.
 """
 import math
-import torch
-import pytest
 
-from cebmf_torch.cebnm.lcash import lcash_posterior_means, po_lcash_posterior_means
+import torch
+
 from cebmf_torch.cebnm.cash_solver import cash_posterior_means
+from cebmf_torch.cebnm.lcash import lcash_posterior_means, po_lcash_posterior_means
 
 
 def _proper_marginal_loglik(betahat, sebetahat, scale, pi):
@@ -91,12 +91,19 @@ def test_lcash_loss_independent_of_penalty():
     (computed from the respective fitted pi). Pre-fix the two values would
     differ by exactly (penalty-1) * sum_g log(pi_g,0)."""
     X, x, s = _make_data()
-    common = dict(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=50, batch_size=512, lr=1e-3, weight_decay=1e-3,
-        ash_init=True, verbose=False,
-        device=torch.device("cpu"), seed=42,
-    )
+    common = {
+        "X": X,
+        "betahat": x,
+        "sebetahat": s,
+        "n_epochs": 50,
+        "batch_size": 512,
+        "lr": 1e-3,
+        "weight_decay": 1e-3,
+        "ash_init": True,
+        "verbose": False,
+        "device": torch.device("cpu"),
+        "seed": 42,
+    }
     res1 = lcash_posterior_means(penalty=1.0, **common)
     res2 = lcash_posterior_means(penalty=1.5, **common)
     ll1 = _proper_marginal_loglik(x, s, res1.scale, res1.pi_np)

--- a/tests/test_lcash_loss_is_marginal_loglik.py
+++ b/tests/test_lcash_loss_is_marginal_loglik.py
@@ -10,6 +10,7 @@ not on the marginal-log-lik scale once ``penalty > 1`` and clamps the inner
 density at ``1e-10``. After the fix it is computed via a single full-batch
 ``logsumexp`` over the saved per-observation pi values.
 """
+
 import math
 
 import torch
@@ -53,10 +54,15 @@ def test_lcash_loss_equals_negative_marginal_loglik_penalty1():
     the proper negative marginal log-lik, not the training-loss surrogate."""
     X, x, s = _make_data()
     res = lcash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=50, batch_size=512,
-        lr=1e-3, weight_decay=1e-3,
-        penalty=1.0, ash_init=True,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=50,
+        batch_size=512,
+        lr=1e-3,
+        weight_decay=1e-3,
+        penalty=1.0,
+        ash_init=True,
         verbose=False,
         device=torch.device("cpu"),
         seed=42,
@@ -65,18 +71,21 @@ def test_lcash_loss_equals_negative_marginal_loglik_penalty1():
     expected_loss = -proper_ll
     # Tight tolerance: the post-fix loss is computed from exactly the same
     # tensor that the test recomputes here.
-    assert abs(res.loss - expected_loss) < 1e-3, (
-        f"LC-ASH loss = {res.loss}, expected -marginal_ll = {expected_loss}"
-    )
+    assert abs(res.loss - expected_loss) < 1e-3, f"LC-ASH loss = {res.loss}, expected -marginal_ll = {expected_loss}"
 
 
 def test_po_lcash_loss_equals_negative_marginal_loglik_penalty1():
     X, x, s = _make_data()
     res = po_lcash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=50, batch_size=512,
-        lr=1e-3, weight_decay=1e-3,
-        penalty=1.0, ash_init=True,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=50,
+        batch_size=512,
+        lr=1e-3,
+        weight_decay=1e-3,
+        penalty=1.0,
+        ash_init=True,
         verbose=False,
         device=torch.device("cpu"),
         seed=42,
@@ -116,8 +125,11 @@ def test_cash_loss_equals_negative_marginal_loglik_penalty1():
     """Same regression test for the CASH solver."""
     X, x, s = _make_data()
     res = cash_posterior_means(
-        X=X, betahat=x, sebetahat=s,
-        n_epochs=20, batch_size=512,
+        X=X,
+        betahat=x,
+        sebetahat=s,
+        n_epochs=20,
+        batch_size=512,
         penalty=1.0,
         device=torch.device("cpu"),
     )

--- a/tests/test_lcash_loss_is_marginal_loglik.py
+++ b/tests/test_lcash_loss_is_marginal_loglik.py
@@ -1,0 +1,120 @@
+"""Regression test for cebmf_torch.cebnm.lcash and cebnm.cash_solver:
+
+Asserts that ``result.loss == -log p(y | fitted prior)`` (i.e. the negative
+full-data marginal log-likelihood, no penalty), as required by the cebmf
+consumer at ``cebmf/cebmf.py:299``: ``self.kl_l[k] = (-resL.loss) - nm_ll_L``.
+
+Before the fix the returned ``loss`` was ``final_epoch_loss`` from training
+(a sum of per-batch ``pen_loglik_loss`` values on the last epoch), which is
+not on the marginal-log-lik scale once ``penalty > 1`` and clamps the inner
+density at ``1e-10``. After the fix it is computed via a single full-batch
+``logsumexp`` over the saved per-observation pi values.
+"""
+import math
+import torch
+import pytest
+
+from cebmf_torch.cebnm.lcash import lcash_posterior_means, po_lcash_posterior_means
+from cebmf_torch.cebnm.cash_solver import cash_posterior_means
+
+
+def _proper_marginal_loglik(betahat, sebetahat, scale, pi):
+    """Compute the proper full-data marginal log-likelihood.
+
+    For each observation g and component k:
+        log p(beta_g | 0, sqrt(se_g^2 + scale_k^2))
+    Then sum_g logsumexp_k (log pi_g,k + log_density_g,k).
+    """
+    se = sebetahat.to(torch.float64)
+    sd = scale.to(torch.float64)
+    bh = betahat.to(torch.float64)
+    pi_d = pi.to(torch.float64)
+
+    total_var = se.unsqueeze(1) ** 2 + sd.unsqueeze(0) ** 2  # (G, K)
+    log_norm_const = -0.5 * torch.log(2 * math.pi * total_var)
+    log_density = log_norm_const - 0.5 * (bh.unsqueeze(1) ** 2) / total_var
+    log_pi = torch.log(pi_d.clamp_min(1e-300))
+    return float(torch.logsumexp(log_pi + log_density, dim=1).sum().item())
+
+
+def _make_data(n=2000, seed=2026):
+    g = torch.Generator().manual_seed(seed)
+    # 30% slab signal at sd 1.0, 70% spike at 0
+    is_slab = (torch.rand(n, generator=g) < 0.3).float()
+    theta = is_slab * torch.randn(n, generator=g)
+    s = torch.full((n,), 0.5)
+    x = theta + s * torch.randn(n, generator=g)
+    X = torch.randn(n, 1, generator=g)
+    return X, x, s
+
+
+def test_lcash_loss_equals_negative_marginal_loglik_penalty1():
+    """With penalty=1.0 (no Dirichlet penalty) the returned loss must be
+    the proper negative marginal log-lik, not the training-loss surrogate."""
+    X, x, s = _make_data()
+    res = lcash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=50, batch_size=512,
+        lr=1e-3, weight_decay=1e-3,
+        penalty=1.0, ash_init=True,
+        verbose=False,
+        device=torch.device("cpu"),
+        seed=42,
+    )
+    proper_ll = _proper_marginal_loglik(x, s, res.scale, res.pi_np)
+    expected_loss = -proper_ll
+    # Tight tolerance: the post-fix loss is computed from exactly the same
+    # tensor that the test recomputes here.
+    assert abs(res.loss - expected_loss) < 1e-3, (
+        f"LC-ASH loss = {res.loss}, expected -marginal_ll = {expected_loss}"
+    )
+
+
+def test_po_lcash_loss_equals_negative_marginal_loglik_penalty1():
+    X, x, s = _make_data()
+    res = po_lcash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=50, batch_size=512,
+        lr=1e-3, weight_decay=1e-3,
+        penalty=1.0, ash_init=True,
+        verbose=False,
+        device=torch.device("cpu"),
+        seed=42,
+    )
+    proper_ll = _proper_marginal_loglik(x, s, res.scale, res.pi_np)
+    assert abs(res.loss - (-proper_ll)) < 1e-3
+
+
+def test_lcash_loss_independent_of_penalty():
+    """Two LC-ASH fits whose only difference is `penalty` should produce
+    `loss` values that, after the fix, both equal the proper marginal log-lik
+    (computed from the respective fitted pi). Pre-fix the two values would
+    differ by exactly (penalty-1) * sum_g log(pi_g,0)."""
+    X, x, s = _make_data()
+    common = dict(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=50, batch_size=512, lr=1e-3, weight_decay=1e-3,
+        ash_init=True, verbose=False,
+        device=torch.device("cpu"), seed=42,
+    )
+    res1 = lcash_posterior_means(penalty=1.0, **common)
+    res2 = lcash_posterior_means(penalty=1.5, **common)
+    ll1 = _proper_marginal_loglik(x, s, res1.scale, res1.pi_np)
+    ll2 = _proper_marginal_loglik(x, s, res2.scale, res2.pi_np)
+    assert abs(res1.loss - (-ll1)) < 1e-3
+    assert abs(res2.loss - (-ll2)) < 1e-3
+
+
+def test_cash_loss_equals_negative_marginal_loglik_penalty1():
+    """Same regression test for the CASH solver."""
+    X, x, s = _make_data()
+    res = cash_posterior_means(
+        X=X, betahat=x, sebetahat=s,
+        n_epochs=20, batch_size=512,
+        penalty=1.0,
+        device=torch.device("cpu"),
+    )
+    # CASH does not return scale or pi_np in the same shape as LC-ASH;
+    # rebuild the proper marginal from res.pi_np and res.scale.
+    proper_ll = _proper_marginal_loglik(x, s, res.scale, res.pi_np)
+    assert abs(res.loss - (-proper_ll)) < 1e-3


### PR DESCRIPTION
Closes #60.

This PR is one of two small, file-disjoint correctness fixes found during a
line-by-line audit of `cebmf_torch`. The companion PR (point-prior factor
pruning direction, `#63`) touches a completely different set of files.
Both are independent and can be merged in either order.

## The bug

`cash_posterior_means` and `lcash._fit_lcash` returned
`loss = total_cash_loss` / `loss = final_loss`, both of which are
**the sum of per-batch training losses on the final epoch** of
`pen_loglik_loss`. That scalar:

- Includes the spike Dirichlet penalty when `penalty > 1` (standard for
  LC-ASH runs with regularised spike weight).
- Computes the per-batch inner term in raw probability space with
  `clamp(min=1e-10)`, so observations whose mixture density underflows
  are hard-clipped to `−log(1e-10) ≈ 23` rather than their true (more
  negative) marginal contribution.
- Two abandoned `# compute proper full negative marginal log-likelihood (no penalty)`
  comments at `cash_solver.py:253, 255` confirm this was a planned
  refactor that never landed.

The value flows into `cebmf/cebmf.py:299, 343` as
`self.kl_l[k] = (-resL.loss) - nm_ll_L`, which is only a KL when
`resL.loss == -log p(y | prior)`. With the bug, `self.obj` is not a valid
ELBO bound, ELBO-based convergence checks are unreliable, and the
user-facing `obj` history is misleading.

## The fix

After training, both `cash_posterior_means` and `_fit_lcash` do one
full-batch `@torch.no_grad()` forward pass and compute the marginal
log-likelihood in log space via `logsumexp`, **without** the spike
Dirichlet penalty. This matches the pattern already used by
`cebnm/emdn.py:288–298` and the meaning required by `cebmf.py`'s KL
bookkeeping. For LC-ASH the per-observation `log_norm` already exists at
`lcash.py:392` inside `_compute_posteriors`; the fix threads that value
up to `_fit_lcash`'s return path as a 5th tuple element rather than
duplicating the computation.

The two dead `# compute proper full negative marginal log-likelihood (no penalty)`
comments at `cash_solver.py:253, 255` are deleted.

## Files touched

- `src/cebmf_torch/cebnm/cash_solver.py` — compute full marginal
  log-lik in log space after training; return `loss=-full_marginal_ll`;
  delete two dead comments.
- `src/cebmf_torch/cebnm/lcash.py` — `_compute_posteriors` now returns
  the marginal log-lik it already computes; `_fit_lcash` threads it
  into `cash_PosteriorMeanNorm.loss` as `-marginal_loglik`.
- `tests/test_lcash_loss_is_marginal_loglik.py` *(new)* — four
  regression tests, see below.

## New regression tests

`tests/test_lcash_loss_is_marginal_loglik.py` fits
`lcash_posterior_means`, `po_lcash_posterior_means`, and
`cash_posterior_means` on a small synthetic problem with `penalty=1.0`,
then independently computes the analytic full-data marginal
log-likelihood under the *fitted* `pi`, scale, and observation noise via
`torch.logsumexp`, and asserts
`result.loss ≈ -analytic_marginal_loglik` to within `1e-3`. With
`penalty=1.0` the new fix returns exactly this value; the old code
returned the per-batch penalised training loss accumulated over the last
epoch, which is on a different scale.

A fourth test fits LC-ASH twice with `penalty=1.0` and `penalty=1.5`
and asserts both fits return `loss = -proper_marginal_log_lik` computed
from their own fitted `pi`. Pre-fix, the two would differ by exactly
`(penalty - 1) * Σ_g log(pi_g,0)`.

All four tests run in `<2 s` on CPU.

## Downstream validation

A representative downstream workflow (MCMC-style cross-cohort
validation run that fits 8 LC-ASH / PO-LC-ASH models with penalties
1.0–2.0) was captured pre-fix against `origin/main`, re-run post-fix,
and the rendered outputs diffed.

- **47/48 result files are byte-identical** across pre- and post-fix.
- The only file that changed is the model-summary TSV, and only the
  `loss` column within it. Every posterior mean, posterior second
  moment, posterior SD, and `mean_prob_null` is unchanged to the full
  precision stored.
- The 8 loss values shift in the direction predicted by the bug
  analysis: tiny (< 1 nat) shifts for `penalty=1.0` fits, where the
  pre-fix `clamp(min=1e-10)` was the only source of bias; larger
  shifts (79–213 nats) for `penalty=1.25–2.0` fits, where the spike
  Dirichlet penalty was the dominant bias term. The model ranking is
  unchanged.

This directly verifies the claim in the PR body: the bug lived
entirely in the reported scalar, not in any computed posterior
quantity.

## What this PR does NOT touch

- The per-observation posterior computation inside
  `_compute_posteriors` — already correct, only its return signature
  grows by one element.
- `pen_loglik_loss` itself — the fix does not need to change the
  training objective, only what is reported as the converged
  `result.loss`.
- The point-prior factor pruning direction bug (`#63`) — split into
  a separate PR because it is file-disjoint and addresses a different
  correctness bug.
- Other audit findings (Jensen guard in `posterior.py:151`, the mutable
  `PRIOR_REGISTRY` builder state in `priors/registry.py`, the
  `mean.abs()` issue in `utils/maths.py:373`, the per-row Python loops
  in `posterior_mean_exp`). These will be filed as separate issues and
  addressed in follow-up PRs to keep review scope tight.

## Reviewer notes

- The full-batch marginal computation in `_fit_lcash` reuses
  `_compute_posteriors`'s existing `log_norm` tensor; the return
  signature change is the only structural modification.
- `_train_model` in `lcash.py` still computes and returns
  `final_epoch_loss`, but the caller at `_fit_lcash` now discards it.
  Leaving that dead path untouched keeps the diff minimal; a follow-up
  PR can trim it.
- The 8-model downstream validation is run on a genetics manuscript's
  cross-cohort evaluation pipeline; the repro data itself is not
  public, but the byte-identical posterior result (47/48 files) and
  the pattern of loss-only shifts are the relevant signals here.
