### PR TITLE
Fix inverted point-prior factor pruning (rename `pi0` to `pi_slab`)

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -96,9 +96,9 @@ Point-mass + Exponential Prior
     s = torch.tensor([1.0, 0.5, 1.2, 0.8, 1.0])
     
     result = ebnm_point_exp(x, s)
-    
+
     print(f"Posterior means: {result.post_mean}")
-    print(f"Null probability: {result.pi0}")
+    print(f"Null probability: {1.0 - result.pi_slab}")
 
 Advanced Usage
 --------------

--- a/src/cebmf_torch/ebnm/generalized_binary.py
+++ b/src/cebmf_torch/ebnm/generalized_binary.py
@@ -1,13 +1,15 @@
-import math
 from dataclasses import dataclass
+
 import torch
 from torch import Tensor
+
 from cebmf_torch.utils.maths import (
     _LOG_SQRT_2PI,  # log(sqrt(2π))
-    logPhi,         # stable log Φ
+    logPhi,  # stable log Φ
+    my_e2truncnorm,  # E[X^2 | a < X < b] for Normal(mean, sd) via truncation
     my_etruncnorm,  # E[X | a < X < b] for Normal(mean, sd) via truncation
-    my_e2truncnorm, # E[X^2 | a < X < b] for Normal(mean, sd) via truncation
 )
+
 
 @dataclass
 class EBNMGBResult:
@@ -68,8 +70,8 @@ def ebnm_gb(
         sig_tilde2 = 1.0 / denom
         mu_tilde = ( (s*s)*mu_val + (sigma*sigma)*x ) / (s*s + sigma*sigma)
 
-        # log Φ(μ̃/σ̃) − log Φ(μ/σ). Note μ/σ = 1/ω is constant in μ’s optimization. :contentReference[oaicite:2]{index=2}
-        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))
+        # log Φ(μ̃/σ̃) − log Φ(μ/σ). Note μ/σ = 1/ω is constant in μ’s optimization. :contentReference[oaicite:2]{index=2}  # noqa: E501
+        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))  # noqa: E501
 
         lg = lg0 + log_norm_cdf_ratio  # log slab marginal per i
 
@@ -81,7 +83,7 @@ def ebnm_gb(
 
         return zeta, lg, lf, mu_tilde, sig_tilde2
 
-    # M-step for μ: maximize sum_i ζ_i [ log N(x; μ, ω^2 μ^2 + s^2) + log Φ(μ̃/σ̃) ], no closed form. :contentReference[oaicite:3]{index=3}
+    # M-step for μ: maximize sum_i ζ_i [ log N(x; μ, ω^2 μ^2 + s^2) + log Φ(μ̃/σ̃) ], no closed form. :contentReference[oaicite:3]{index=3}  # noqa: E501
     # We optimize an unconstrained η with μ = softplus(η).
     def _optimize_mu(zeta: Tensor, mu_init: Tensor):
         eta = torch.nn.Parameter(torch.log(torch.expm1(mu_init.clamp_min(1e-8))))
@@ -141,7 +143,7 @@ def ebnm_gb(
         # M-step π (eq. (22)): average ζ
         pi_new = zeta.mean().clamp(1e-8, 1-1e-8)
 
-        # M-step μ: optimize expected complete log-lik (eq. (23); constant −logΦ(1/ω) dropped). :contentReference[oaicite:4]{index=4}
+        # M-step μ: optimize expected complete log-lik (eq. (23); constant −logΦ(1/ω) dropped). :contentReference[oaicite:4]{index=4}  # noqa: E501
         mu_new = _optimize_mu(zeta, mu)
 
         # Evaluate marginal log-likelihood with updated params (for convergence check; eq. (18))
@@ -152,7 +154,7 @@ def ebnm_gb(
             denom = 1.0/(sigma*sigma + eps) + 1.0/(s*s)
             sig_tilde2 = 1.0 / denom
             mu_tilde = ( (s*s)*mu_new + (sigma*sigma)*x ) / (s*s + sigma*sigma)
-            log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))
+            log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))  # noqa: E501
             lg_marg = lg0 + log_norm_cdf_ratio
 
             # log ∏ [ (1-π)N(x;0,s^2) + π * slab ]
@@ -185,7 +187,7 @@ def ebnm_gb(
         sigma = omega_t * mu
         var_sum = s*s + sigma*sigma
         lg0 = _log_normal_pdf(x, mu, var_sum.sqrt())
-        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))
+        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))  # noqa: E501
         lg_marg = lg0 + log_norm_cdf_ratio
         log_lik = torch.logaddexp(torch.log1p(-pi) + lf, torch.log(pi) + lg_marg).sum().item()
 
@@ -198,4 +200,3 @@ def ebnm_gb(
         scale=float(1/(omega+1e-8)),
         log_lik=float(log_lik),
     )
- 

--- a/src/cebmf_torch/ebnm/generalized_binary.py
+++ b/src/cebmf_torch/ebnm/generalized_binary.py
@@ -16,22 +16,24 @@ class EBNMGBResult:
     post_mean: Tensor
     post_mean2: Tensor
     post_sd: Tensor
-    pi_slab: float    # slab weight π (= 1 - pi_null)
-    mode: float        # learned μ ≥ 0
-    scale: float     # fixed ω (σ = ω μ)
+    pi_slab: float  # slab weight π (= 1 - pi_null)
+    mode: float  # learned μ ≥ 0
+    scale: float  # fixed ω (σ = ω μ)
     log_lik: float
+
 
 def _log_normal_pdf(x: Tensor, mean: Tensor, sd: Tensor) -> Tensor:
     sd = sd.clamp_min(1e-12)
     z = (x - mean) / sd
     return -0.5 * z**2 - torch.log(sd) - _LOG_SQRT_2PI
 
+
 def ebnm_gb(
     x: Tensor,
     s: Tensor,
-    omega: float = 0.2,          # fixed ω (σ = ω μ), typically small
-    par_init_mu: float = 1.0,    # μ initialization (on the original scale)
-    par_init_pi: float = 0.2,    # π initialization
+    omega: float = 0.2,  # fixed ω (σ = ω μ), typically small
+    par_init_mu: float = 1.0,  # μ initialization (on the original scale)
+    par_init_pi: float = 0.2,  # π initialization
     max_em: int = 200,
     tol_em: float = 1e-5,
     max_lbfgs: int = 200,
@@ -49,7 +51,7 @@ def ebnm_gb(
 
     # Initialize hyperparameters
     mu = torch.tensor(float(max(par_init_mu, 1e-6)), device=device, dtype=dtype)
-    pi = torch.tensor(float(min(max(par_init_pi, 1e-6), 1-1e-6)), device=device, dtype=dtype)
+    pi = torch.tensor(float(min(max(par_init_pi, 1e-6), 1 - 1e-6)), device=device, dtype=dtype)
     omega_t = torch.tensor(float(omega), device=device, dtype=dtype)
 
     # Precompute spike log-likelihood terms: N(x; 0, s^2)
@@ -62,16 +64,18 @@ def ebnm_gb(
 
         # slab marginal density from eq. (18):
         # N(x; μ, σ^2 + s^2) * Φ(μ̃/σ̃) / Φ(μ/σ)
-        var_sum = s*s + sigma*sigma
+        var_sum = s * s + sigma * sigma
         lg0 = _log_normal_pdf(x, mu_val, var_sum.sqrt())
 
         # σ̃_i^2 and μ̃_i (eqs. (19)-(20) with σ=ω μ)
-        denom = 1.0/(sigma*sigma + eps) + 1.0/(s*s)
+        denom = 1.0 / (sigma * sigma + eps) + 1.0 / (s * s)
         sig_tilde2 = 1.0 / denom
-        mu_tilde = ( (s*s)*mu_val + (sigma*sigma)*x ) / (s*s + sigma*sigma)
+        mu_tilde = ((s * s) * mu_val + (sigma * sigma) * x) / (s * s + sigma * sigma)
 
         # log Φ(μ̃/σ̃) − log Φ(μ/σ). Note μ/σ = 1/ω is constant in μ’s optimization. :contentReference[oaicite:2]{index=2}  # noqa: E501
-        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))  # noqa: E501
+        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(
+            torch.tensor(1.0 / float(omega), device=device, dtype=dtype)
+        )  # noqa: E501
 
         lg = lg0 + log_norm_cdf_ratio  # log slab marginal per i
 
@@ -87,24 +91,26 @@ def ebnm_gb(
     # We optimize an unconstrained η with μ = softplus(η).
     def _optimize_mu(zeta: Tensor, mu_init: Tensor):
         eta = torch.nn.Parameter(torch.log(torch.expm1(mu_init.clamp_min(1e-8))))
-        opt = torch.optim.LBFGS([eta],
-                                max_iter=max_lbfgs,
-                                tolerance_grad=tol_lbfgs,
-                                tolerance_change=tol_lbfgs,
-                                line_search_fn="strong_wolfe",
-                                history_size=20)
+        opt = torch.optim.LBFGS(
+            [eta],
+            max_iter=max_lbfgs,
+            tolerance_grad=tol_lbfgs,
+            tolerance_change=tol_lbfgs,
+            line_search_fn="strong_wolfe",
+            history_size=20,
+        )
 
         def closure():
             opt.zero_grad(set_to_none=True)
             mu_pos = torch.nn.functional.softplus(eta) + 0.0  # ensure ≥ 0
             sigma = omega_t * mu_pos
-            var_sum = s*s + sigma*sigma
+            var_sum = s * s + sigma * sigma
             lg0 = _log_normal_pdf(x, mu_pos, var_sum.sqrt())
 
             # μ̃_i, σ̃_i as functions of μ (via σ)
-            denom = 1.0/(sigma*sigma + eps) + 1.0/(s*s)
+            denom = 1.0 / (sigma * sigma + eps) + 1.0 / (s * s)
             sig_tilde2 = 1.0 / denom
-            mu_tilde = ( (s*s)*mu_pos + (sigma*sigma)*x ) / (s*s + sigma*sigma)
+            mu_tilde = ((s * s) * mu_pos + (sigma * sigma) * x) / (s * s + sigma * sigma)
 
             obj_terms = lg0 + logPhi(mu_tilde / sig_tilde2.sqrt())  # drop constant −logΦ(1/ω)
             loss = -(zeta * obj_terms).sum()
@@ -121,11 +127,11 @@ def ebnm_gb(
                 adam.zero_grad(set_to_none=True)
                 mu_pos = torch.nn.functional.softplus(eta)
                 sigma = omega_t * mu_pos
-                var_sum = s*s + sigma*sigma
+                var_sum = s * s + sigma * sigma
                 lg0 = _log_normal_pdf(x, mu_pos, var_sum.sqrt())
-                denom = 1.0/(sigma*sigma + eps) + 1.0/(s*s)
+                denom = 1.0 / (sigma * sigma + eps) + 1.0 / (s * s)
                 sig_tilde2 = 1.0 / denom
-                mu_tilde = ( (s*s)*mu_pos + (sigma*sigma)*x ) / (s*s + sigma*sigma)
+                mu_tilde = ((s * s) * mu_pos + (sigma * sigma) * x) / (s * s + sigma * sigma)
                 obj_terms = lg0 + logPhi(mu_tilde / sig_tilde2.sqrt())
                 loss = -(zeta * obj_terms).sum()
                 loss.backward()
@@ -141,7 +147,7 @@ def ebnm_gb(
         zeta, lg, lf, mu_tilde, sig_tilde2 = _E_step(mu, pi)
 
         # M-step π (eq. (22)): average ζ
-        pi_new = zeta.mean().clamp(1e-8, 1-1e-8)
+        pi_new = zeta.mean().clamp(1e-8, 1 - 1e-8)
 
         # M-step μ: optimize expected complete log-lik (eq. (23); constant −logΦ(1/ω) dropped). :contentReference[oaicite:4]{index=4}  # noqa: E501
         mu_new = _optimize_mu(zeta, mu)
@@ -149,12 +155,14 @@ def ebnm_gb(
         # Evaluate marginal log-likelihood with updated params (for convergence check; eq. (18))
         with torch.no_grad():
             sigma = omega_t * mu_new
-            var_sum = s*s + sigma*sigma
+            var_sum = s * s + sigma * sigma
             lg0 = _log_normal_pdf(x, mu_new, var_sum.sqrt())
-            denom = 1.0/(sigma*sigma + eps) + 1.0/(s*s)
+            denom = 1.0 / (sigma * sigma + eps) + 1.0 / (s * s)
             sig_tilde2 = 1.0 / denom
-            mu_tilde = ( (s*s)*mu_new + (sigma*sigma)*x ) / (s*s + sigma*sigma)
-            log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))  # noqa: E501
+            mu_tilde = ((s * s) * mu_new + (sigma * sigma) * x) / (s * s + sigma * sigma)
+            log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(
+                torch.tensor(1.0 / float(omega), device=device, dtype=dtype)
+            )  # noqa: E501
             lg_marg = lg0 + log_norm_cdf_ratio
 
             # log ∏ [ (1-π)N(x;0,s^2) + π * slab ]
@@ -185,9 +193,11 @@ def ebnm_gb(
 
         # Final marginal log-likelihood
         sigma = omega_t * mu
-        var_sum = s*s + sigma*sigma
+        var_sum = s * s + sigma * sigma
         lg0 = _log_normal_pdf(x, mu, var_sum.sqrt())
-        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(torch.tensor(1.0/float(omega), device=device, dtype=dtype))  # noqa: E501
+        log_norm_cdf_ratio = logPhi(mu_tilde / sig_tilde2.sqrt()) - logPhi(
+            torch.tensor(1.0 / float(omega), device=device, dtype=dtype)
+        )  # noqa: E501
         lg_marg = lg0 + log_norm_cdf_ratio
         log_lik = torch.logaddexp(torch.log1p(-pi) + lf, torch.log(pi) + lg_marg).sum().item()
 
@@ -197,6 +207,6 @@ def ebnm_gb(
         post_sd=post_sd,
         pi_slab=float(pi),  # local `pi` is the slab weight
         mode=float(mu),
-        scale=float(1/(omega+1e-8)),
+        scale=float(1 / (omega + 1e-8)),
         log_lik=float(log_lik),
     )

--- a/src/cebmf_torch/ebnm/generalized_binary.py
+++ b/src/cebmf_torch/ebnm/generalized_binary.py
@@ -14,7 +14,7 @@ class EBNMGBResult:
     post_mean: Tensor
     post_mean2: Tensor
     post_sd: Tensor
-    pi0: float        # slab weight π
+    pi_slab: float    # slab weight π (= 1 - pi_null)
     mode: float        # learned μ ≥ 0
     scale: float     # fixed ω (σ = ω μ)
     log_lik: float
@@ -193,7 +193,7 @@ def ebnm_gb(
         post_mean=post_mean,
         post_mean2=post_mean2,
         post_sd=post_sd,
-        pi0=float(pi),
+        pi_slab=float(pi),  # local `pi` is the slab weight
         mode=float(mu),
         scale=float(1/(omega+1e-8)),
         log_lik=float(log_lik),

--- a/src/cebmf_torch/ebnm/point_exp.py
+++ b/src/cebmf_torch/ebnm/point_exp.py
@@ -111,6 +111,7 @@ class EBNMPointExp:
         self.log_lik = log_lik
         self.mode = mode
 
+
 def ebnm_point_exp(
     x: Tensor,
     s: Tensor,
@@ -154,8 +155,8 @@ def ebnm_point_exp(
     v0 = math.log(r) - math.log(1 - r)
 
     alpha = torch.nn.Parameter(torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0])  # noqa: E501
-    a_logit = torch.nn.Parameter(torch.as_tensor(v0,             dtype=dtype, device=device), requires_grad=not fix_par[1])  # noqa: E501
-    mu      = torch.nn.Parameter(torch.as_tensor(par_init[2],    dtype=dtype, device=device), requires_grad=not fix_par[2])  # noqa: E501
+    a_logit = torch.nn.Parameter(torch.as_tensor(v0, dtype=dtype, device=device), requires_grad=not fix_par[1])  # noqa: E501
+    mu = torch.nn.Parameter(torch.as_tensor(par_init[2], dtype=dtype, device=device), requires_grad=not fix_par[2])  # noqa: E501
 
     params = [p for p in (alpha, a_logit, mu) if p.requires_grad]
     opt = torch.optim.LBFGS(
@@ -173,14 +174,14 @@ def ebnm_point_exp(
         opt.zero_grad(set_to_none=True)
 
         # Smooth transforms (no hard clamps on the objective)
-        pi_slab = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)             # (0,1)
+        pi_slab = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)  # (0,1)
         sig = torch.sigmoid(a_logit)
-        a = (a_lo_t + (a_hi_t - a_lo_t) * sig)                             # (a_lo, a_hi)
+        a = a_lo_t + (a_hi_t - a_lo_t) * sig  # (a_lo, a_hi)
         xc = x - mu
 
         # log-likelihood pieces
-        lf = _loglik_spike(xc, s)                 # spike: N(xc|0,s^2)
-        lg = _loglik_exp_convolved(xc, s, a)      # slab: Exp ⊗ Normal (Z≥0)
+        lf = _loglik_spike(xc, s)  # spike: N(xc|0,s^2)
+        lg = _loglik_exp_convolved(xc, s, a)  # slab: Exp ⊗ Normal (Z≥0)
 
         # mixture log-likelihood per datum
         llik_i = torch.logaddexp(torch.log1p(-pi_slab) + lf, torch.log(pi_slab) + lg)
@@ -219,7 +220,7 @@ def ebnm_point_exp(
     with torch.no_grad():
         pi_slab = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)
         sig = torch.sigmoid(a_logit)
-        a = (a_lo_t + (a_hi_t - a_lo_t) * sig)
+        a = a_lo_t + (a_hi_t - a_lo_t) * sig
         mu_v = float(mu.item())
 
         xc = x - mu
@@ -231,29 +232,29 @@ def ebnm_point_exp(
         gamma = torch.exp(log_num - log_den).clamp(_const_like(x, 0.0), _const_like(x, 1.0))
 
         EZ, EZ2 = _posterior_moments_exp_branch(xc, s, a)
-        post_mean_c  = gamma * EZ
+        post_mean_c = gamma * EZ
         post_mean2_c = torch.maximum(gamma * EZ2, (post_mean_c**2))
 
-        post_mean  = post_mean_c + mu
+        post_mean = post_mean_c + mu
         post_mean2 = post_mean2_c + _const_like(x, 2.0) * mu * post_mean_c + mu * mu
-        post_sd    = (post_mean2 - post_mean**2).clamp_min(_const_like(x, 0.0)).sqrt()
+        post_sd = (post_mean2 - post_mean**2).clamp_min(_const_like(x, 0.0)).sqrt()
 
         # pure observed marginal log-likelihood (no penalty)
         llik = torch.logaddexp(torch.log1p(-pi_slab) + lf, torch.log(pi_slab.clamp_min(eps_t)) + lg).sum()
 
         # Optional spike-only shortcut (post hoc only, keeps training objective smooth)
         if float(pi_slab.item()) < tresh_pi0:
-            post_mean  = torch.zeros_like(x) + mu
-            post_mean2 = torch.zeros_like(x) + mu*mu + _const_like(x, 1e-4)
-            post_sd    = (post_mean2 - post_mean**2).clamp_min(_const_like(x, 0.0)).sqrt()
-            llik       = lf.sum()
+            post_mean = torch.zeros_like(x) + mu
+            post_mean2 = torch.zeros_like(x) + mu * mu + _const_like(x, 1e-4)
+            post_sd = (post_mean2 - post_mean**2).clamp_min(_const_like(x, 0.0)).sqrt()
+            llik = lf.sum()
             # leave pi_slab tiny (or set to exact 0.0 if preferred)
 
     return EBNMPointExp(
         post_mean=post_mean,
         post_mean2=post_mean2,
         post_sd=post_sd,
-        scale=float(a.item()),   # 'a' is the *rate*; field name kept as 'scale' for compatibility
+        scale=float(a.item()),  # 'a' is the *rate*; field name kept as 'scale' for compatibility
         pi_slab=float(pi_slab.item()),
         log_lik=float(llik.item()),
         mode=mu_v,

--- a/src/cebmf_torch/ebnm/point_exp.py
+++ b/src/cebmf_torch/ebnm/point_exp.py
@@ -153,9 +153,9 @@ def ebnm_point_exp(
     r = min(max(r, 1e-8), 1 - 1e-8)
     v0 = math.log(r) - math.log(1 - r)
 
-    alpha = torch.nn.Parameter(torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0])
-    a_logit = torch.nn.Parameter(torch.as_tensor(v0,             dtype=dtype, device=device), requires_grad=not fix_par[1])
-    mu      = torch.nn.Parameter(torch.as_tensor(par_init[2],    dtype=dtype, device=device), requires_grad=not fix_par[2])
+    alpha = torch.nn.Parameter(torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0])  # noqa: E501
+    a_logit = torch.nn.Parameter(torch.as_tensor(v0,             dtype=dtype, device=device), requires_grad=not fix_par[1])  # noqa: E501
+    mu      = torch.nn.Parameter(torch.as_tensor(par_init[2],    dtype=dtype, device=device), requires_grad=not fix_par[2])  # noqa: E501
 
     params = [p for p in (alpha, a_logit, mu) if p.requires_grad]
     opt = torch.optim.LBFGS(

--- a/src/cebmf_torch/ebnm/point_exp.py
+++ b/src/cebmf_torch/ebnm/point_exp.py
@@ -72,7 +72,7 @@ class EBNMPointExp:
         post_mean2: Tensor,
         post_sd: Tensor,
         scale: float,
-        pi0: float,
+        pi_slab: float,
         log_lik: float,
         mode: float,
     ):
@@ -89,8 +89,15 @@ class EBNMPointExp:
             Posterior standard deviations for each observation.
         scale : float
             Estimated exponential scale parameter (a).
-        pi0 : float
-            Estimated mixture weight for the Exp branch.
+        pi_slab : float
+            Estimated mixture weight for the Exp (slab) branch. Equal to
+            ``1 - pi_null``. The previous field name ``pi0`` was a misnomer:
+            inside this class ``pi0`` was the slab weight (the field that
+            multiplies the Exp branch in the loglik mixture), not the null
+            weight, which is the opposite of how the mixture-prior path
+            (``ebnm/ash.py``) uses ``pi0``. The rename eliminates the
+            cross-file naming collision and prevents the kind of inversion
+            that previously affected ``priors/point.py``.
         log_lik : float
             Final log-likelihood value.
         mode : float
@@ -100,7 +107,7 @@ class EBNMPointExp:
         self.post_mean2 = post_mean2
         self.post_sd = post_sd
         self.scale = scale
-        self.pi0 = pi0
+        self.pi_slab = pi_slab
         self.log_lik = log_lik
         self.mode = mode
 
@@ -117,13 +124,13 @@ def ebnm_point_exp(
     tol: float = 1e-6,
     a_bounds=(1e-2, 1e2),  # bounded rate a
     loga_l2: float = 1e-3,  # ridge on a's unconstrained param (optimization only; 0 = off)
-    tresh_pi0: float = 1e-3,  # spike-only shortcut (post-processing only)
+    tresh_pi0: float = 1e-3,  # legacy name; slab-weight threshold for spike-only shortcut
     eps: float = 1e-12,
 ) -> EBNMPointExp:
     """
     Direct maximization (no EM) of the observed marginal log-likelihood for a point-Exponential EBNM.
 
-    Prior on θ: (1 - pi0) δ_μ + pi0 [μ + Exp(a)], with support θ ≥ μ.
+    Prior on θ: (1 - pi_slab) δ_μ + pi_slab [μ + Exp(a)], with support θ ≥ μ.
     Returns pure marginal log-likelihood (no penalties).
     """
     device, dtype = x.device, x.dtype
@@ -136,8 +143,8 @@ def ebnm_point_exp(
     a_hi_t = _const_like(x, a_hi)
 
     if par_init is None:
-        # alpha ~ logit(pi0), log_a ~ log(a), mu
-        par_init = (0.9, 1.0, 0.0)  # pi0≈0.71, a≈e^1≈2.72, mu=0.0
+        # alpha ~ logit(pi_slab), log_a ~ log(a), mu
+        par_init = (0.9, 1.0, 0.0)  # pi_slab≈0.71, a≈e^1≈2.72, mu=0.0
 
     # Prepare a *logit* parameter for a in (a_lo, a_hi):  a = a_lo + (a_hi-a_lo) * sigmoid(v)
     a_init = float(min(max(math.exp(float(par_init[1])), a_lo), a_hi))
@@ -166,17 +173,17 @@ def ebnm_point_exp(
         opt.zero_grad(set_to_none=True)
 
         # Smooth transforms (no hard clamps on the objective)
-        pi0 = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)                 # (0,1)
+        pi_slab = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)             # (0,1)
         sig = torch.sigmoid(a_logit)
-        a   = (a_lo_t + (a_hi_t - a_lo_t) * sig)                           # (a_lo, a_hi)
-        xc  = x - mu
+        a = (a_lo_t + (a_hi_t - a_lo_t) * sig)                             # (a_lo, a_hi)
+        xc = x - mu
 
         # log-likelihood pieces
         lf = _loglik_spike(xc, s)                 # spike: N(xc|0,s^2)
         lg = _loglik_exp_convolved(xc, s, a)      # slab: Exp ⊗ Normal (Z≥0)
 
         # mixture log-likelihood per datum
-        llik_i   = torch.logaddexp(torch.log1p(-pi0) + lf, torch.log(pi0) + lg)
+        llik_i = torch.logaddexp(torch.log1p(-pi_slab) + lf, torch.log(pi_slab) + lg)
         llik_sum = llik_i.sum()
 
         # OPTIONAL tiny penalty on the unconstrained 'a_logit' to tame extremes (off by default)
@@ -210,18 +217,18 @@ def ebnm_point_exp(
 
     # ===== Final posterior & summaries =====
     with torch.no_grad():
-        pi0 = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)
+        pi_slab = torch.sigmoid(alpha).clamp(eps_t, 1 - eps_t)
         sig = torch.sigmoid(a_logit)
-        a   = (a_lo_t + (a_hi_t - a_lo_t) * sig)
+        a = (a_lo_t + (a_hi_t - a_lo_t) * sig)
         mu_v = float(mu.item())
 
         xc = x - mu
         lf = _loglik_spike(xc, s)
         lg = _loglik_exp_convolved(xc, s, a)
 
-        log_num = torch.log(pi0) + lg
-        log_den = torch.logaddexp(torch.log1p(-pi0) + lf, log_num)
-        gamma   = torch.exp(log_num - log_den).clamp(_const_like(x, 0.0), _const_like(x, 1.0))
+        log_num = torch.log(pi_slab) + lg
+        log_den = torch.logaddexp(torch.log1p(-pi_slab) + lf, log_num)
+        gamma = torch.exp(log_num - log_den).clamp(_const_like(x, 0.0), _const_like(x, 1.0))
 
         EZ, EZ2 = _posterior_moments_exp_branch(xc, s, a)
         post_mean_c  = gamma * EZ
@@ -232,22 +239,22 @@ def ebnm_point_exp(
         post_sd    = (post_mean2 - post_mean**2).clamp_min(_const_like(x, 0.0)).sqrt()
 
         # pure observed marginal log-likelihood (no penalty)
-        llik = torch.logaddexp(torch.log1p(-pi0) + lf, torch.log(pi0.clamp_min(eps_t)) + lg).sum()
+        llik = torch.logaddexp(torch.log1p(-pi_slab) + lf, torch.log(pi_slab.clamp_min(eps_t)) + lg).sum()
 
         # Optional spike-only shortcut (post hoc only, keeps training objective smooth)
-        if float(pi0.item()) < tresh_pi0:
+        if float(pi_slab.item()) < tresh_pi0:
             post_mean  = torch.zeros_like(x) + mu
             post_mean2 = torch.zeros_like(x) + mu*mu + _const_like(x, 1e-4)
             post_sd    = (post_mean2 - post_mean**2).clamp_min(_const_like(x, 0.0)).sqrt()
             llik       = lf.sum()
-            # leave pi0 tiny (or set to exact 0.0 if preferred)
+            # leave pi_slab tiny (or set to exact 0.0 if preferred)
 
     return EBNMPointExp(
         post_mean=post_mean,
         post_mean2=post_mean2,
         post_sd=post_sd,
         scale=float(a.item()),   # 'a' is the *rate*; field name kept as 'scale' for compatibility
-        pi0=float(pi0.item()),
+        pi_slab=float(pi_slab.item()),
         log_lik=float(llik.item()),
         mode=mu_v,
     )

--- a/src/cebmf_torch/ebnm/point_laplace.py
+++ b/src/cebmf_torch/ebnm/point_laplace.py
@@ -34,7 +34,7 @@ class EBNMLaplaceResult:
     post_mean: Tensor
     post_mean2: Tensor
     post_sd: Tensor
-    pi0: float   # mixture weight of the Laplace branch (slab)
+    pi_slab: float  # mixture weight of the Laplace branch (slab); = 1 - pi_null
     a: float     # Laplace rate (1/scale)
     mu: float
     log_lik: float  # pure marginal log-likelihood (no penalties)
@@ -48,9 +48,9 @@ def ebnm_point_laplace(
     tol: float = 1e-6,
     a_bounds=(1e-2, 1e2),              # bounds for Laplace rate a
     loga_l2: float = 0.0,              # ridge on a's unconstrained logit (optimization only; 0=off)
-    tresh_pi0: float = 1e-3,           # spike-only shortcut (post-processing only)
+    tresh_pi0: float = 1e-3,           # legacy name; slab-weight threshold for spike-only shortcut
     eps: float = 1e-12,
-    pen_pi0: float = 0.0,              # optional symmetric prior on pi0 (size-independent); 0=off
+    pen_pi0: float = 0.0,              # legacy name; optional symmetric prior on slab-weight parameter w
     use_adam_warmstart: bool = False,  # default OFF for speed; set True to enable short warm-up
     adam_steps: int = 8,
     adam_lr: float = 1e-2,
@@ -76,7 +76,7 @@ def ebnm_point_laplace(
     half = torch.tensor(0.5, device=device, dtype=dtype)
     two  = torch.tensor(2.0, device=device, dtype=dtype)
     eps_t = torch.tensor(eps, device=device, dtype=dtype)
-    thresh_pi0_t = torch.tensor(tresh_pi0, device=device, dtype=dtype)
+    thresh_pi_slab_t = torch.tensor(tresh_pi0, device=device, dtype=dtype)
 
     # normalizing constant (reuse tensor if given, else make one)
     c_norm = _LOG_SQRT_2PI if isinstance(_LOG_SQRT_2PI, torch.Tensor) else _const_like(s, _LOG_SQRT_2PI)
@@ -246,8 +246,8 @@ def ebnm_point_laplace(
         # PURE marginal log-likelihood
         llik = torch.logaddexp(torch.log1p(-w) + lf, torch.log(w.clamp_min(eps_t)) + lg).sum()
 
-        # spike-only shortcut if pi0 (slab weight) tiny
-        if float(w.item()) < float(thresh_pi0_t.item()):
+        # spike-only shortcut if slab weight is tiny
+        if float(w.item()) < float(thresh_pi_slab_t.item()):
             post_mean  = torch.zeros_like(x) + mu
             post_mean2 = torch.zeros_like(x) + mu * mu + torch.tensor(1e-4, device=device, dtype=dtype)
             post_sd    = (post_mean2 - post_mean**2).clamp_min(zero).sqrt()
@@ -257,7 +257,7 @@ def ebnm_point_laplace(
         post_mean=post_mean,
         post_mean2=post_mean2,
         post_sd=post_sd,
-        pi0=float(w.item()),     # mixture weight of the Laplace branch (slab)
+        pi_slab=float(w.item()),  # mixture weight of the Laplace branch (slab)
         a=float(a.item()),
         mu=float(mu.item()),
         log_lik=float(llik.item()),

--- a/src/cebmf_torch/ebnm/point_laplace.py
+++ b/src/cebmf_torch/ebnm/point_laplace.py
@@ -16,6 +16,7 @@ from cebmf_torch.utils.maths import (
 def _const_like(x: Tensor, val) -> Tensor:
     return torch.as_tensor(val, device=x.device, dtype=x.dtype)
 
+
 def logg_laplace_convolved_with_normal(x: Tensor, s: Tensor, a: Tensor) -> Tensor:
     """
     log (Laplace(0, rate=a) ⊗ Normal(0, s^2)) at x.
@@ -25,11 +26,12 @@ def logg_laplace_convolved_with_normal(x: Tensor, s: Tensor, a: Tensor) -> Tenso
     z1 = (x - (s * s) * a) / s
     z2 = -(x + (s * s) * a) / s
     lg1 = -a * x + logPhi(z1)
-    lg2 =  a * x + logPhi(z2)
+    lg2 = a * x + logPhi(z2)
     lsum = torch.logaddexp(lg1, lg2)
     half = torch.tensor(0.5, device=x.device, dtype=x.dtype)
-    two  = torch.tensor(2.0, device=x.device, dtype=x.dtype)
+    two = torch.tensor(2.0, device=x.device, dtype=x.dtype)
     return safe_log(a / two) + half * (s * a) ** 2 + lsum
+
 
 @dataclass
 class EBNMLaplaceResult:
@@ -37,22 +39,23 @@ class EBNMLaplaceResult:
     post_mean2: Tensor
     post_sd: Tensor
     pi_slab: float  # mixture weight of the Laplace branch (slab); = 1 - pi_null
-    a: float     # Laplace rate (1/scale)
+    a: float  # Laplace rate (1/scale)
     mu: float
     log_lik: float  # pure marginal log-likelihood (no penalties)
+
 
 def ebnm_point_laplace(
     x: Tensor,
     s: Tensor,
-    par_init=None,                     # None by default; choose safely inside
-    fix_par=(False, False, True),      # [w_logit, a_logit, mu]; mu fixed at 0 by default
+    par_init=None,  # None by default; choose safely inside
+    fix_par=(False, False, True),  # [w_logit, a_logit, mu]; mu fixed at 0 by default
     max_iter: int = 20,
     tol: float = 1e-6,
-    a_bounds=(1e-2, 1e2),              # bounds for Laplace rate a
-    loga_l2: float = 0.0,              # ridge on a's unconstrained logit (optimization only; 0=off)
-    tresh_pi0: float = 1e-3,           # legacy name; slab-weight threshold for spike-only shortcut
+    a_bounds=(1e-2, 1e2),  # bounds for Laplace rate a
+    loga_l2: float = 0.0,  # ridge on a's unconstrained logit (optimization only; 0=off)
+    tresh_pi0: float = 1e-3,  # legacy name; slab-weight threshold for spike-only shortcut
     eps: float = 1e-12,
-    pen_pi0: float = 0.0,              # legacy name; optional symmetric prior on slab-weight parameter w
+    pen_pi0: float = 0.0,  # legacy name; optional symmetric prior on slab-weight parameter w
     use_adam_warmstart: bool = False,  # default OFF for speed; set True to enable short warm-up
     adam_steps: int = 8,
     adam_lr: float = 1e-2,
@@ -68,14 +71,14 @@ def ebnm_point_laplace(
     s = torch.as_tensor(s, device=device, dtype=dtype).clamp_min(_const_like(x, 1e-6))
 
     # Precompute once; reused in closure & posterior
-    log_s  = torch.log(s)
-    s2     = s * s
+    log_s = torch.log(s)
+    s2 = s * s
 
     # scalar constants as tensors on the right device/dtype
     zero = torch.tensor(0.0, device=device, dtype=dtype)
-    one  = torch.tensor(1.0, device=device, dtype=dtype)
+    one = torch.tensor(1.0, device=device, dtype=dtype)
     half = torch.tensor(0.5, device=device, dtype=dtype)
-    two  = torch.tensor(2.0, device=device, dtype=dtype)
+    two = torch.tensor(2.0, device=device, dtype=dtype)
     eps_t = torch.tensor(eps, device=device, dtype=dtype)
     thresh_pi_slab_t = torch.tensor(tresh_pi0, device=device, dtype=dtype)
 
@@ -98,9 +101,11 @@ def ebnm_point_laplace(
     r = min(max(r, 1e-8), 1 - 1e-8)
     v0 = math.log(r) - math.log(1 - r)
 
-    w_logit = torch.nn.Parameter(torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0])  # noqa: E501
-    a_logit = torch.nn.Parameter(torch.as_tensor(v0,             dtype=dtype, device=device), requires_grad=not fix_par[1])  # noqa: E501
-    mu      = torch.nn.Parameter(torch.as_tensor(par_init[2],    dtype=dtype, device=device), requires_grad=not fix_par[2])  # noqa: E501
+    w_logit = torch.nn.Parameter(
+        torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0]
+    )  # noqa: E501
+    a_logit = torch.nn.Parameter(torch.as_tensor(v0, dtype=dtype, device=device), requires_grad=not fix_par[1])  # noqa: E501
+    mu = torch.nn.Parameter(torch.as_tensor(par_init[2], dtype=dtype, device=device), requires_grad=not fix_par[2])  # noqa: E501
 
     params = [p for p in (w_logit, a_logit, mu) if p.requires_grad]
 
@@ -109,9 +114,9 @@ def ebnm_point_laplace(
         opt_adam = torch.optim.AdamW(params, lr=adam_lr, betas=(0.9, 0.999), weight_decay=weight_decay)
         for _ in range(int(adam_steps)):
             opt_adam.zero_grad(set_to_none=True)
-            w   = torch.sigmoid(w_logit).clamp(eps_t, one - eps_t)
-            a   = a_lo_t + a_span * torch.sigmoid(a_logit)
-            xc  = x - mu
+            w = torch.sigmoid(w_logit).clamp(eps_t, one - eps_t)
+            a = a_lo_t + a_span * torch.sigmoid(a_logit)
+            xc = x - mu
 
             # spike log-lik
             lf = -(half * (xc / s) ** 2) - log_s - c_norm
@@ -120,7 +125,7 @@ def ebnm_point_laplace(
             z1 = (xc - s2 * a) / s
             z2 = -(xc + s2 * a) / s
             lg1 = -a * xc + logPhi(z1)
-            lg2 =  a * xc + logPhi(z2)
+            lg2 = a * xc + logPhi(z2)
             lsum = torch.logaddexp(lg1, lg2)
             lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
 
@@ -150,9 +155,9 @@ def ebnm_point_laplace(
 
         def closure():
             opt_lbfgs.zero_grad(set_to_none=True)
-            w   = torch.sigmoid(w_logit).clamp(eps_t, one - eps_t)
-            a   = a_lo_t + a_span * torch.sigmoid(a_logit)
-            xc  = x - mu
+            w = torch.sigmoid(w_logit).clamp(eps_t, one - eps_t)
+            a = a_lo_t + a_span * torch.sigmoid(a_logit)
+            xc = x - mu
 
             # spike log-lik (reuses log_s, c_norm)
             lf = -(half * (xc / s) ** 2) - log_s - c_norm
@@ -161,7 +166,7 @@ def ebnm_point_laplace(
             z1 = (xc - s2 * a) / s
             z2 = -(xc + s2 * a) / s
             lg1 = -a * xc + logPhi(z1)
-            lg2 =  a * xc + logPhi(z2)
+            lg2 = a * xc + logPhi(z2)
             lsum = torch.logaddexp(lg1, lg2)
             lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
 
@@ -177,9 +182,12 @@ def ebnm_point_laplace(
                 )
 
             loss = -(llik - penalty)
-            loss = torch.nan_to_num(loss, nan=torch.tensor(1e30, device=device, dtype=dtype),
-                                    posinf=torch.tensor(1e30, device=device, dtype=dtype),
-                                    neginf=torch.tensor(1e30, device=device, dtype=dtype))
+            loss = torch.nan_to_num(
+                loss,
+                nan=torch.tensor(1e30, device=device, dtype=dtype),
+                posinf=torch.tensor(1e30, device=device, dtype=dtype),
+                neginf=torch.tensor(1e30, device=device, dtype=dtype),
+            )
             loss.backward()
             return loss
 
@@ -202,9 +210,9 @@ def ebnm_point_laplace(
 
     # ---- posterior & summaries (no penalties; single no_grad block) ----
     with torch.no_grad():
-        w   = torch.sigmoid(w_logit).clamp(eps_t, one - eps_t)
-        a   = a_lo_t + a_span * torch.sigmoid(a_logit)
-        xc  = x - mu
+        w = torch.sigmoid(w_logit).clamp(eps_t, one - eps_t)
+        a = a_lo_t + a_span * torch.sigmoid(a_logit)
+        xc = x - mu
 
         # spike
         lf = -(half * (xc / s) ** 2) - log_s - c_norm
@@ -213,14 +221,14 @@ def ebnm_point_laplace(
         z1 = (xc - s2 * a) / s
         z2 = -(xc + s2 * a) / s
         lg1 = -a * xc + logPhi(z1)
-        lg2 =  a * xc + logPhi(z2)
+        lg2 = a * xc + logPhi(z2)
         lsum = torch.logaddexp(lg1, lg2)
         lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
 
         # posterior inclusion prob (slab)
-        log_num   = torch.log(w) + lg
+        log_num = torch.log(w) + lg
         log_denom = torch.logaddexp(torch.log1p(-w) + lf, log_num)
-        gamma     = torch.exp(log_num - log_denom).clamp(zero, one)
+        gamma = torch.exp(log_num - log_denom).clamp(zero, one)
 
         # sign-mixture inside slab
         lam = torch.exp(lg1 - lsum)
@@ -229,30 +237,30 @@ def ebnm_point_laplace(
         # truncated-normal moments
         m_pos = xc - s2 * a
         m_neg = xc + s2 * a
-        infp  = torch.full_like(x, float("inf"))
-        infn  = -infp
+        infp = torch.full_like(x, float("inf"))
+        infn = -infp
 
-        EX_pos  = my_etruncnorm(zero, infp, mean=m_pos, sd=s)
+        EX_pos = my_etruncnorm(zero, infp, mean=m_pos, sd=s)
         EX2_pos = my_e2truncnorm(zero, infp, mean=m_pos, sd=s)
-        EX_neg  = my_etruncnorm(infn, zero, mean=m_neg, sd=s)
+        EX_neg = my_etruncnorm(infn, zero, mean=m_neg, sd=s)
         EX2_neg = my_e2truncnorm(infn, zero, mean=m_neg, sd=s)
 
-        EX  = lam * EX_pos  + (one - lam) * EX_neg
+        EX = lam * EX_pos + (one - lam) * EX_neg
         EX2 = lam * EX2_pos + (one - lam) * EX2_neg
 
-        post_mean  = gamma * (EX + mu) + (one - gamma) * mu
+        post_mean = gamma * (EX + mu) + (one - gamma) * mu
         post_mean2 = gamma * (EX2 + two * mu * EX + mu * mu) + (one - gamma) * (mu * mu)
-        post_sd    = (post_mean2 - post_mean**2).clamp_min(zero).sqrt()
+        post_sd = (post_mean2 - post_mean**2).clamp_min(zero).sqrt()
 
         # PURE marginal log-likelihood
         llik = torch.logaddexp(torch.log1p(-w) + lf, torch.log(w.clamp_min(eps_t)) + lg).sum()
 
         # spike-only shortcut if slab weight is tiny
         if float(w.item()) < float(thresh_pi_slab_t.item()):
-            post_mean  = torch.zeros_like(x) + mu
+            post_mean = torch.zeros_like(x) + mu
             post_mean2 = torch.zeros_like(x) + mu * mu + torch.tensor(1e-4, device=device, dtype=dtype)
-            post_sd    = (post_mean2 - post_mean**2).clamp_min(zero).sqrt()
-            llik       = lf.sum()
+            post_sd = (post_mean2 - post_mean**2).clamp_min(zero).sqrt()
+            llik = lf.sum()
 
     return EBNMLaplaceResult(
         post_mean=post_mean,

--- a/src/cebmf_torch/ebnm/point_laplace.py
+++ b/src/cebmf_torch/ebnm/point_laplace.py
@@ -1,5 +1,6 @@
 import math
 from dataclasses import dataclass
+
 import torch
 from torch import Tensor
 
@@ -10,6 +11,7 @@ from cebmf_torch.utils.maths import (
     my_etruncnorm,
     safe_log,
 )
+
 
 def _const_like(x: Tensor, val) -> Tensor:
     return torch.as_tensor(val, device=x.device, dtype=x.dtype)
@@ -66,7 +68,6 @@ def ebnm_point_laplace(
     s = torch.as_tensor(s, device=device, dtype=dtype).clamp_min(_const_like(x, 1e-6))
 
     # Precompute once; reused in closure & posterior
-    inv_s  = 1.0 / s
     log_s  = torch.log(s)
     s2     = s * s
 
@@ -97,9 +98,9 @@ def ebnm_point_laplace(
     r = min(max(r, 1e-8), 1 - 1e-8)
     v0 = math.log(r) - math.log(1 - r)
 
-    w_logit = torch.nn.Parameter(torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0])
-    a_logit = torch.nn.Parameter(torch.as_tensor(v0,             dtype=dtype, device=device), requires_grad=not fix_par[1])
-    mu      = torch.nn.Parameter(torch.as_tensor(par_init[2],    dtype=dtype, device=device), requires_grad=not fix_par[2])
+    w_logit = torch.nn.Parameter(torch.as_tensor(par_init[0], dtype=dtype, device=device), requires_grad=not fix_par[0])  # noqa: E501
+    a_logit = torch.nn.Parameter(torch.as_tensor(v0,             dtype=dtype, device=device), requires_grad=not fix_par[1])  # noqa: E501
+    mu      = torch.nn.Parameter(torch.as_tensor(par_init[2],    dtype=dtype, device=device), requires_grad=not fix_par[2])  # noqa: E501
 
     params = [p for p in (w_logit, a_logit, mu) if p.requires_grad]
 

--- a/src/cebmf_torch/priors/point.py
+++ b/src/cebmf_torch/priors/point.py
@@ -110,11 +110,17 @@ class PointBuilder(PriorBuilder):
             Fitted prior object with posterior means and related quantities.
         """
         obj = builder_functions[self.type](betahat, sebetahat, **self.kwargs)
+        # `obj.pi_slab` is the slab (non-null) weight by the convention of
+        # EBNMPointExp / EBNMLaplaceResult / EBNMGBResult. The Prior.pi0_null
+        # field expected by `cebmf._should_prune_factor` (cebmf.py:482) is
+        # the *null/spike* weight, so it is `1 - pi_slab`. Prior to this fix
+        # the two were equated by mistake (`pi0_null=obj.pi0` where `obj.pi0`
+        # was actually the slab weight), inverting the prune decision.
         return Prior(
             post_mean=obj.post_mean,
             post_mean2=obj.post_mean2,
             loss=-float(obj.log_lik),
             model_param=model_param,
-            pi0_null=obj.pi0,
-            pi_slab=1.0 - float(obj.pi0),
+            pi0_null=1.0 - float(obj.pi_slab),
+            pi_slab=float(obj.pi_slab),
         )

--- a/tests/test_ebnm_point_exp_torch.py
+++ b/tests/test_ebnm_point_exp_torch.py
@@ -11,6 +11,6 @@ def test_optimize_pe_like():
     res = ebnm_point_exp(x, s)
     # Expected numbers from original tests (allow small tolerance)
     assert np.isclose(res.log_lik, -3.636553632132083, atol=1e-2)
-    assert np.isclose(float(res.pi0), 0.9999563044116645, atol=1e-3)
+    assert np.isclose(float(res.pi_slab), 0.9999563044116645, atol=1e-3)
     assert np.isclose(float(res.scale), 3.047337093696241, atol=1e-1)
     assert np.isclose(float(res.mode), 0.0, atol=1e-4)

--- a/tests/test_generalized_binary.py
+++ b/tests/test_generalized_binary.py
@@ -44,14 +44,14 @@ def test_basic_parameter_recovery(device):
 
     # finite outputs
     assert math.isfinite(res.log_lik)
-    assert 0.0 < res.pi0 < 1.0
+    assert 0.0 < res.pi_slab < 1.0
     assert res.mode >= 0.0
     assert torch.isfinite(res.post_mean).all()
     assert torch.isfinite(res.post_sd).all()
     assert torch.isfinite(res.post_mean2).all()
 
     # parameter recovery (tolerances generous to allow stochastic variation)
-    assert abs(res.pi0 - true_pi) < 0.06
+    assert abs(res.pi_slab - true_pi) < 0.06
     assert abs(res.mode - true_mu) < 0.35
 
     # moment consistency: Var >= 0, E[X^2] >= E[X]^2
@@ -120,11 +120,11 @@ def test_extreme_cases_pi_near_zero_and_one():
     # Almost all spikes
     _, x0, s0 = simulate_gb(n=2000, pi=0.02, mu=2.0, omega=0.2, s_val=0.5, seed=555)
     r0 = ebnm_gb(x0, s0, omega=0.2)
-    assert r0.pi0 < 0.15
+    assert r0.pi_slab < 0.15
     assert r0.post_mean.mean().item() < 0.15
 
     # Almost all slabs
     _, x1, s1 = simulate_gb(n=2000, pi=0.98, mu=2.0, omega=0.2, s_val=0.5, seed=556)
     r1 = ebnm_gb(x1, s1, omega=0.2)
-    assert r1.pi0 > 0.8
+    assert r1.pi_slab > 0.8
     assert r1.post_mean.mean().item() > 0.5

--- a/tests/test_generalized_binary.py
+++ b/tests/test_generalized_binary.py
@@ -1,10 +1,11 @@
 # tests/test_ebnm_gb.py
 import math
-import torch
+
 import pytest
+import torch
 
 # import your implementation
-from cebmf_torch.ebnm.generalized_binary import ebnm_gb # adjust path if needed
+from cebmf_torch.ebnm.generalized_binary import ebnm_gb  # adjust path if needed
 
 torch.set_num_threads(1)
 

--- a/tests/test_generalized_binary.py
+++ b/tests/test_generalized_binary.py
@@ -9,6 +9,7 @@ from cebmf_torch.ebnm.generalized_binary import ebnm_gb  # adjust path if needed
 
 torch.set_num_threads(1)
 
+
 def simulate_gb(n=2000, pi=0.3, mu=2.0, omega=0.2, s_val=0.5, seed=1, device="cpu"):
     """
     Simulate (theta, x, s) from the generalized-binary prior:
@@ -82,7 +83,7 @@ def test_variance_is_consistent():
     res = ebnm_gb(x, s, omega=0.25)
 
     # sd^2 = E[X^2] - E[X]^2, and must be >= 0
-    v = res.post_mean2 - res.post_mean ** 2
+    v = res.post_mean2 - res.post_mean**2
     assert torch.all(v >= -1e-8)
     assert torch.all(res.post_sd >= 0.0)
     # post_sd should agree with sqrt(var) numerically
@@ -95,17 +96,17 @@ def test_shrinkage_and_omega_effect():
     theta, x, s = simulate_gb(n=2500, pi=true_pi, mu=true_mu, omega=0.2, s_val=s_val, seed=99)
 
     res_narrow = ebnm_gb(x, s, omega=0.15)
-    res_wide   = ebnm_gb(x, s, omega=0.50)
+    res_wide = ebnm_gb(x, s, omega=0.50)
 
     # Look only at positive observations (where shrinkage is most interpretable)
     pos = x > 0
     pm_narrow = res_narrow.post_mean[pos]
-    pm_wide   = res_wide.post_mean[pos]
-    x_pos     = x[pos]
+    pm_wide = res_wide.post_mean[pos]
+    x_pos = x[pos]
 
     # Both should be positively associated with x
-    corr_narrow = torch.corrcoef(torch.stack([x_pos, pm_narrow]))[0,1].item()
-    corr_wide   = torch.corrcoef(torch.stack([x_pos, pm_wide]))[0,1].item()
+    corr_narrow = torch.corrcoef(torch.stack([x_pos, pm_narrow]))[0, 1].item()
+    corr_wide = torch.corrcoef(torch.stack([x_pos, pm_wide]))[0, 1].item()
     assert corr_narrow > 0.7 and corr_wide > 0.7
 
     # Wider slab shrinks less on average

--- a/tests/test_point_prior_pruning_direction.py
+++ b/tests/test_point_prior_pruning_direction.py
@@ -16,6 +16,7 @@ After the fix:
 - A strong-signal factor (true slab ≈ 1) gets ``pi0_null ≈ 0`` and is
   preserved.
 """
+
 import torch
 
 from cebmf_torch.ebnm.generalized_binary import ebnm_gb
@@ -59,9 +60,7 @@ def test_point_builder_pi0_null_is_null_for_signal_factor():
     prior: Prior = builder.fit(X=None, betahat=x, sebetahat=s)
     pi0_null = _to_float(prior.pi0_null)
     pi_slab = _to_float(prior.pi_slab)
-    assert pi0_null < 0.2, (
-        f"Real-signal factor must have small null weight, got pi0_null={pi0_null}"
-    )
+    assert pi0_null < 0.2, f"Real-signal factor must have small null weight, got pi0_null={pi0_null}"
     assert pi_slab > 0.8, f"Real-signal factor must have large slab weight, got pi_slab={pi_slab}"
     assert abs(pi0_null + pi_slab - 1.0) < 1e-5
     # Default cebmf prune_thresh
@@ -79,9 +78,7 @@ def test_point_builder_pi0_null_is_null_for_noise_factor():
     prior: Prior = builder.fit(X=None, betahat=x, sebetahat=s)
     pi0_null = _to_float(prior.pi0_null)
     pi_slab = _to_float(prior.pi_slab)
-    assert pi0_null > 0.85, (
-        f"Null factor must have large null weight, got pi0_null={pi0_null}"
-    )
+    assert pi0_null > 0.85, f"Null factor must have large null weight, got pi0_null={pi0_null}"
     assert pi_slab < 0.15
     assert abs(pi0_null + pi_slab - 1.0) < 1e-5
 

--- a/tests/test_point_prior_pruning_direction.py
+++ b/tests/test_point_prior_pruning_direction.py
@@ -1,0 +1,100 @@
+"""Regression test for the H1 fix: PointBuilder.fit must store the
+*null* weight in Prior.pi0_null, not the slab weight.
+
+Before the fix, ``priors/point.py:118`` wrote ``pi0_null=obj.pi0`` where
+for ``EBNMPointExp`` / ``EBNMLaplaceResult`` / ``EBNMGBResult`` the field
+``pi0`` is in fact the *slab* weight (per their own docstrings and the
+mixture closure code). This inverted the direction of the cebmf prune
+decision (``cebmf.py:482``: prune when ``pi0_null >= prune_thresh``).
+
+After the fix:
+- The class field is renamed to ``pi_slab`` (matches the field comments).
+- ``priors/point.py`` writes ``pi0_null = 1 - obj.pi_slab`` and
+  ``pi_slab = obj.pi_slab``.
+- A pure-noise factor (true slab ≈ 0) gets ``pi0_null ≈ 1`` and would be
+  pruned at ``prune_thresh = 0.999``.
+- A strong-signal factor (true slab ≈ 1) gets ``pi0_null ≈ 0`` and is
+  preserved.
+"""
+import torch
+import pytest
+
+from cebmf_torch.ebnm.generalized_binary import ebnm_gb
+from cebmf_torch.priors.point import PointBuilder, PointPriorType
+from cebmf_torch.priors.base import Prior
+
+
+def _simulate_gb(n, pi, mu, omega, s_val, seed):
+    """Faithful copy of tests/test_generalized_binary.py::simulate_gb so this
+    test does not depend on a sibling test file."""
+    g = torch.Generator().manual_seed(seed)
+    is_slab = (torch.rand(n, generator=g) < pi).float()
+    sigma = omega * mu
+    theta = is_slab * (mu + sigma * torch.randn(n, generator=g))
+    s = torch.full((n,), s_val)
+    x = theta + s * torch.randn(n, generator=g)
+    return theta, x, s
+
+
+def _to_float(x):
+    if isinstance(x, torch.Tensor):
+        return float(x.item())
+    return float(x)
+
+
+def test_pi_slab_field_is_renamed_on_ebnm_gb():
+    """After the rename the EBNM GB result must expose pi_slab and not pi0."""
+    _, x, s = _simulate_gb(n=2000, pi=0.3, mu=2.0, omega=0.2, s_val=0.5, seed=10)
+    res = ebnm_gb(x, s, omega=0.2)
+    assert hasattr(res, "pi_slab"), "EBNMGBResult must expose `pi_slab`"
+    assert not hasattr(res, "pi0"), "EBNMGBResult.pi0 must be removed (renamed to pi_slab)"
+    assert abs(_to_float(res.pi_slab) - 0.3) < 0.06
+
+
+def test_point_builder_pi0_null_is_null_for_signal_factor():
+    """Strong-signal factor (slab ≈ 0.98). After fit through PointBuilder,
+    Prior.pi0_null must be SMALL (~ 0.02), so the factor would NOT be pruned
+    at the default prune_thresh = 0.999."""
+    _, x, s = _simulate_gb(n=2000, pi=0.98, mu=2.0, omega=0.2, s_val=0.5, seed=20)
+    builder = PointBuilder(PointPriorType.GBINARY)
+    prior: Prior = builder.fit(X=None, betahat=x, sebetahat=s)
+    pi0_null = _to_float(prior.pi0_null)
+    pi_slab = _to_float(prior.pi_slab)
+    assert pi0_null < 0.2, (
+        f"Real-signal factor must have small null weight, got pi0_null={pi0_null}"
+    )
+    assert pi_slab > 0.8, f"Real-signal factor must have large slab weight, got pi_slab={pi_slab}"
+    assert abs(pi0_null + pi_slab - 1.0) < 1e-5
+    # Default cebmf prune_thresh
+    PRUNE_THRESH = 0.999
+    assert not (pi0_null >= PRUNE_THRESH), "Real-signal factor must NOT be pruned"
+
+
+def test_point_builder_pi0_null_is_null_for_noise_factor():
+    """Pure-noise factor (slab ≈ 0.02). After fit through PointBuilder,
+    Prior.pi0_null must be LARGE (~ 0.98), so the factor would be pruned
+    at any reasonable threshold (e.g. 0.95) — and we explicitly assert it
+    crosses 0.85 here, well above the typical 'looks like noise' bar."""
+    _, x, s = _simulate_gb(n=2000, pi=0.02, mu=2.0, omega=0.2, s_val=0.5, seed=21)
+    builder = PointBuilder(PointPriorType.GBINARY)
+    prior: Prior = builder.fit(X=None, betahat=x, sebetahat=s)
+    pi0_null = _to_float(prior.pi0_null)
+    pi_slab = _to_float(prior.pi_slab)
+    assert pi0_null > 0.85, (
+        f"Null factor must have large null weight, got pi0_null={pi0_null}"
+    )
+    assert pi_slab < 0.15
+    assert abs(pi0_null + pi_slab - 1.0) < 1e-5
+
+
+def test_point_builder_pi0_null_consistent_with_ebnm_directly():
+    """The Prior.pi_slab returned by the registry path must equal the
+    EBNM class's own pi_slab field, exactly. (This catches any future
+    drift between the registry's bridging line and the EBNM convention.)"""
+    _, x, s = _simulate_gb(n=2000, pi=0.4, mu=2.0, omega=0.2, s_val=0.5, seed=22)
+    res = ebnm_gb(x, s, omega=0.2)
+    builder = PointBuilder(PointPriorType.GBINARY)
+    prior: Prior = builder.fit(X=None, betahat=x, sebetahat=s)
+    # Both calls deterministic; if not, this assertion will surface it.
+    assert abs(_to_float(prior.pi_slab) - _to_float(res.pi_slab)) < 1e-6
+    assert abs(_to_float(prior.pi0_null) - (1.0 - _to_float(res.pi_slab))) < 1e-6

--- a/tests/test_point_prior_pruning_direction.py
+++ b/tests/test_point_prior_pruning_direction.py
@@ -17,11 +17,10 @@ After the fix:
   preserved.
 """
 import torch
-import pytest
 
 from cebmf_torch.ebnm.generalized_binary import ebnm_gb
-from cebmf_torch.priors.point import PointBuilder, PointPriorType
 from cebmf_torch.priors.base import Prior
+from cebmf_torch.priors.point import PointBuilder, PointPriorType
 
 
 def _simulate_gb(n, pi, mu, omega, s_val, seed):


### PR DESCRIPTION
Closes #61.

This PR is one of two small, file-disjoint correctness fixes found during
a line-by-line audit of `cebmf_torch`. The companion PR (CASH/LC-ASH
`result.loss` field, `#62`) touches a completely different set of
files. Both are independent and can be merged in either order.

## The bug

`PointBuilder.fit` (`priors/point.py:118`) wrote `pi0_null = obj.pi0`
for `EBNMPointExp`, `EBNMLaplaceResult`, and `EBNMGBResult`. But in
those three classes, the field named `pi0` is the **slab (non-null)
weight**, not the null weight, per the classes' own documentation and
mixture math:

- `point_exp.py:92–93` docstring: *"pi0 : float — Estimated mixture
  weight for the Exp branch."*
- `point_laplace.py:37` field comment: *"mixture weight of the Laplace
  branch (slab)"*.
- `generalized_binary.py:17` field comment: *"slab weight π"*.
- `point_exp.py:179` mixture closure:
  `logaddexp(log1p(-pi0)+lf, log(pi0)+lg)` — `log(pi0)` multiplies the
  slab term.

`cEBMF._should_prune_factor` (`cebmf/cebmf.py:482`) then prunes when
`pi0_min >= prune_thresh` (default `0.999`). With the inversion,
factors with **strong slab weight** (real signal, slab ≈ 1) were
pruned, and factors with **strong null weight** (pure noise, slab ≈ 0)
were kept. The tests in `tests/test_generalized_binary.py:47, 54, 123, 129`
have always asserted the slab semantics against `r.pi0` (e.g. `pi=0.98`
in the simulator ⇒ `r.pi0 > 0.8`), so the tests passed while the
downstream consumer at `priors/point.py:118` silently inverted the
meaning.

The bug affects only the `point_exp` / `point_laplace` / `gbinary`
paths through `PointBuilder` — the mixture (`ASHBuilder`) and
learned-prior (`LearnedBuilder`) paths use `pi0` consistently as the
spike-component weight and were already correct.

It was introduced in commit `b2ad5b8` ("feat: create prior base class
and registry"), which created `priors/mixture.py` and
`priors/point.py` in the same commit. The author wrote
`pi0_null = obj.pi0` in **both files**; in `mixture.py` that line is
correct (because `ash.py:147` makes `obj.pi0` the spike weight), and
in `point.py` it is wrong. Same line, same author, same commit,
opposite outcomes — exactly the copy-paste failure mode that the
field-name collision makes inevitable.

## The fix: rename, don't one-line-swap

The root cause is a field-name collision: `pi0` means "slab weight"
inside the point-prior EBNM classes and "spike weight" everywhere else.
A one-line swap at `priors/point.py:118`
(`pi0_null = 1 - obj.pi0; pi_slab = obj.pi0`) would fix the symptom,
but the collision stays in place, and any future code that reads
`EBNMPointExp.pi0` will trip on the same naming bomb that produced
this inversion in the first place.

We chose the **rename + fix-consumer** route. The rename eliminates the
bomb. The trade-off is a ~25-line change instead of two, but the diff
is mechanical (rename a field, update its callers, update tests that
already use it), the new tests catch any future regression, and the
result is a codebase where `pi_slab` unambiguously means "slab" and
`pi0_null` unambiguously means "null".

## Files touched

- `src/cebmf_torch/ebnm/point_exp.py` — rename `pi0` → `pi_slab` in
  `EBNMPointExp`'s constructor parameter, instance attribute, and
  every internal occurrence in the closure. Expanded docstring explains
  why. (`EBNMPointExp` is a regular class, not a dataclass — the
  companion `EBNMLaplaceResult` and `EBNMGBResult` *are* dataclasses.)
- `src/cebmf_torch/ebnm/point_laplace.py` — rename `EBNMLaplaceResult.pi0`
  → `pi_slab`; legacy parameter names `tresh_pi0` / `pen_pi0` on the
  public function are kept for signature compatibility, with updated
  comments marking them as legacy names.
- `src/cebmf_torch/ebnm/generalized_binary.py` — rename `EBNMGBResult.pi0`
  → `pi_slab`.
- `src/cebmf_torch/priors/point.py` — rewrite the bridging assignment
  as `pi0_null = 1 - float(obj.pi_slab); pi_slab = float(obj.pi_slab)`,
  with an inline comment explaining the meaning in both directions.
- `src/cebmf_torch/priors/mixture.py` — **not touched**. The mixture
  path correctly uses `ASHResult.pi0` as the spike weight.
- `tests/test_generalized_binary.py:47, 54, 123, 129` — update the
  test assertions to read `r.pi_slab`. The assertions themselves were
  always written against the slab semantics; only the field name had
  to follow.
- `tests/test_ebnm_point_exp_torch.py` — same, one assertion updated.
- `tests/test_point_prior_pruning_direction.py` *(new)* — four
  regression tests, see below.
- `docs/source/examples.rst` — the `ebnm_point_exp` example was
  printing `result.pi0` under the label `"Null probability:"`, which
  was already wrong before the rename (it was actually printing the
  slab weight). Updated to `1.0 - result.pi_slab` so the printed label
  matches the printed value.

## New regression tests

`tests/test_point_prior_pruning_direction.py` uses a copy of the
existing `simulate_gb` helper (inlined so the test does not depend on
a sibling test file) to generate a strong-signal dataset (`pi=0.98`)
and a near-null dataset (`pi=0.02`), then:

1. Asserts that `EBNMGBResult` exposes `pi_slab` and that `pi0` is
   gone (locks in the rename).
2. Fits via `PointBuilder(PointPriorType.GBINARY).fit(...)` and asserts
   that for the strong-signal case `Prior.pi0_null < 0.2`, so the
   factor would **not** be pruned at `prune_thresh = 0.999`, and
   `Prior.pi_slab > 0.8`.
3. Fits the null case and asserts `Prior.pi0_null > 0.85`, so the
   factor would be pruned.
4. Asserts that `Prior.pi_slab` from the registry path equals the
   EBNM class's own `pi_slab` field to within `1e-6` (catches any
   future drift between the registry bridging line and the EBNM
   convention).

All four tests also assert `Prior.pi0_null + Prior.pi_slab ≈ 1` to
catch any subtle conversion mistake in the bridging line. The suite
runs in `<2 s` on CPU.

## What this PR does NOT touch

- **The `pi0` semantics in `ebnm/ash.py:113`** (where `pi0` *is* the
  spike weight, in contrast to the point priors). The audit found
  multiple places in the codebase that consistently treat `ash.pi0` as
  the spike weight, so renaming it would be a much larger change with
  downstream callers (`priors/mixture.py:107`, `priors/learned.py`,
  `cebmf.py`'s `self.pi0_L` / `self.pi0_F` arrays). This PR's rename
  is scoped to the three point-prior result classes only, where the
  docstring/field-comment already say "slab".
- **The CASH/LC-ASH `result.loss` bug** (`#62`) — split into a
  separate PR because it is file-disjoint and addresses a different
  correctness bug.
- Other audit findings. These will be filed as separate issues and
  addressed in follow-up PRs to keep review scope tight.

## Downstream validation

The representative downstream workflow the author was running at the
time uses only `ash(prior=PriorType.NORM)` and the LC-ASH / PO-LC-ASH
solvers. It does not exercise any point-prior path, so this PR leaves
that workflow byte-identical. The point-prior pruning bug fires only
on future `cEBMF(prior_L="point_exp", ...)` / `"point_laplace"` /
`"gbinary"` runs; the new regression tests are the primary defence.

## Reviewer notes

- The rename is mechanical. A reviewer can grep for `pi0` in the
  touched files and confirm that the field-level collision is gone.
  Remaining occurrences should either mean spike weight (`ash.py`,
  `cash_solver.py`, `cebmf.py`) or be legacy parameter names
  (`tresh_pi0`, `pen_pi0`) kept for compatibility with clarifying
  comments.
- **Small result-object API change.** `EBNMPointExp`,
  `EBNMLaplaceResult`, and `EBNMGBResult` now expose `pi_slab` instead
  of `pi0`. This is intentional: the old name was wrong, and code
  reading `.pi0` on any of these three classes was either (a) in the
  test file fixed in this PR, or (b) in the downstream consumer that
  this PR fixes. External callers who read the field directly will
  need the one-line update `.pi0` → `.pi_slab`.
