### PR TITLE
Fix my_e2truncnorm second moment for negative / left-truncated means

### DIFF
--- a/src/cebmf_torch/utils/maths.py
+++ b/src/cebmf_torch/utils/maths.py
@@ -431,11 +431,6 @@ def my_e2truncnorm(a, b, mean=0.0, sd=1.0, precision: str = "auto"):
     alpha = torch.where(flip, -beta, alpha)
     beta = torch.where(flip, -orig_alpha, beta)
 
-    # Absolute mean handling. `mean.abs()` is a no-op for mean==0, so we don't
-    # need the previous `if not torch.all(mean == 0): mean = mean.abs()` guard
-    # — that guard fired a host sync on every call.
-    mean = mean.abs()
-
     pnorm_diff = logscale_sub(logPhi(beta), logPhi(alpha))
 
     alpha_frac = alpha * torch.exp(torch.clamp(logphi(alpha) - pnorm_diff, max=300.0))
@@ -464,7 +459,12 @@ def my_e2truncnorm(a, b, mean=0.0, sd=1.0, precision: str = "auto"):
 
     # NOTE: my_etruncnorm expects (a,b,mean,sd). For standardized alpha/beta, use mean=0, sd=1.
     # Forward the same ``precision`` so the inner call doesn't silently re-upcast back to float64.
-    res = mean**2 + 2 * mean * sd * my_etruncnorm(alpha, beta, 0.0, 1.0, precision=precision) + sd**2 * scaled_res
+    # alpha/beta were flipped for numerical stability when (alpha>0 & beta>0); the first
+    # moment of the *original* standardized interval is the negation in that case. We must
+    # keep ``mean`` signed here: the cross term is 2*mean*sd*E[Z], not 2*|mean|*sd*E[Z].
+    ez = my_etruncnorm(alpha, beta, 0.0, 1.0, precision=precision)
+    ez = torch.where(flip, -ez, ez)
+    res = mean**2 + 2 * mean * sd * ez + sd**2 * scaled_res
 
     # Branchless degenerate-sd handling — see _apply_degenerate_sd_first_moment
     # for the rationale (no host sync per call).

--- a/tests/test_e2truncnorm_negative_mean.py
+++ b/tests/test_e2truncnorm_negative_mean.py
@@ -31,8 +31,8 @@ def _brute_e2(a, b, mean, sd, n=200_001):
     hi = mean + 12.0 * sd if math.isinf(b) else b
     x = np.linspace(lo, hi, n)
     pdf = np.exp(-0.5 * ((x - mean) / sd) ** 2) / (sd * math.sqrt(2.0 * math.pi))
-    z = np.trapz(pdf, x)
-    m2 = np.trapz(x * x * pdf, x)
+    z = np.trapezoid(pdf, x)
+    m2 = np.trapezoid(x * x * pdf, x)
     return m2 / z
 
 

--- a/tests/test_e2truncnorm_negative_mean.py
+++ b/tests/test_e2truncnorm_negative_mean.py
@@ -1,0 +1,76 @@
+"""Regression tests for my_e2truncnorm second moments with negative / non-zero means.
+
+The previous implementation took ``mean = mean.abs()`` before reconstructing
+E[X^2] = mean^2 + 2*mean*sd*E[Z] + sd^2*E[Z^2]. Because the internal ``flip``
+only fires when both standardized bounds are positive, the cross term
+``2*mean*sd*E[Z]`` kept the wrong sign for left-truncated / negative-mean
+intervals. That made the second moment wrong (and sign-asymmetric) and could
+drive E[X^2] below E[X]^2, collapsing posterior standard deviations to zero.
+
+These tests use a dependency-free numpy quadrature ground truth plus the exact
+reflection-symmetry invariant E[X^2 | a<X<b, mean] == E[X^2 | -b<X<-a, -mean].
+"""
+
+import math
+
+import numpy as np
+import torch
+
+from cebmf_torch.utils.maths import my_e2truncnorm
+
+CPU = torch.device("cpu")
+
+
+def _t(v):
+    return torch.tensor(float(v), dtype=torch.float64, device=CPU)
+
+
+def _brute_e2(a, b, mean, sd, n=200_001):
+    """E[X^2 | a<X<b] for X~N(mean, sd^2) via fine-grid trapezoidal quadrature."""
+    lo = mean - 12.0 * sd if math.isinf(a) else a
+    hi = mean + 12.0 * sd if math.isinf(b) else b
+    x = np.linspace(lo, hi, n)
+    pdf = np.exp(-0.5 * ((x - mean) / sd) ** 2) / (sd * math.sqrt(2.0 * math.pi))
+    z = np.trapz(pdf, x)
+    m2 = np.trapz(x * x * pdf, x)
+    return m2 / z
+
+
+CASES = [
+    # (a, b, mean, sd)
+    (-np.inf, 0.0, -0.5, 1.0),
+    (-np.inf, 0.0, -2.0, 1.0),
+    (-np.inf, 2.0, -1.0, 1.0),
+    (0.0, np.inf, 0.5, 1.0),
+    (-3.0, 3.0, -1.0, 1.0),
+    (-np.inf, 0.0, 0.5, 1.0),
+    (0.0, np.inf, -1.9, 1.0),
+    (1.0, 3.0, 0.5, 1.0),
+    (0.0, np.inf, -2.0, 0.5),
+    (-2.0, 5.0, 2.0, 1.5),
+]
+
+
+def test_e2truncnorm_matches_quadrature():
+    for a, b, mean, sd in CASES:
+        got = float(my_e2truncnorm(_t(a), _t(b), _t(mean), _t(sd)))
+        ref = _brute_e2(a, b, mean, sd)
+        assert abs(got - ref) < 1e-3, f"({a},{b},{mean},{sd}): got {got}, expected {ref}"
+
+
+def test_e2truncnorm_reflection_symmetry():
+    # E[X^2 | a<X<b, N(mean,sd^2)] == E[X^2 | -b<X<-a, N(-mean,sd^2)]
+    for a, b, mean, sd in CASES:
+        left = float(my_e2truncnorm(_t(a), _t(b), _t(mean), _t(sd)))
+        right = float(my_e2truncnorm(_t(-b), _t(-a), _t(-mean), _t(sd)))
+        assert abs(left - right) < 1e-6, f"asymmetry for ({a},{b},{mean},{sd}): {left} vs {right}"
+
+
+def test_e2truncnorm_never_below_first_moment_squared():
+    # E[X^2] >= E[X]^2 must always hold; the bug violated this for negative means.
+    from cebmf_torch.utils.maths import my_etruncnorm
+
+    for a, b, mean, sd in CASES:
+        e1 = float(my_etruncnorm(_t(a), _t(b), _t(mean), _t(sd)))
+        e2 = float(my_e2truncnorm(_t(a), _t(b), _t(mean), _t(sd)))
+        assert e2 >= e1 * e1 - 1e-9, f"E[X^2]={e2} < E[X]^2={e1 * e1} for ({a},{b},{mean},{sd})"


### PR DESCRIPTION
**Impact: must fix (correctness).** `ebnm_point_laplace` returns wrong
posterior second moments for negative observations.

`my_e2truncnorm` took `mean = mean.abs()` before reconstructing
`E[X^2] = mean^2 + 2*mean*sd*E[Z] + sd^2*E[Z^2]`, but the internal `flip` only
fires when both standardized bounds are positive. For left-truncated or
negative-mean intervals the cross term `2*mean*sd*E[Z]` kept the wrong sign, so
the second moment was wrong and sign-asymmetric, and could fall below `E[X]^2`
and collapse posterior SDs to 0.

**Affected output:** `ebnm_point_laplace` returns a wrong second moment (and
`post_sd = 0`) for negative observations. For `x = -2, s = 1, w = 0.6, a = 1.5`
the posterior second moment was `0.32` vs the true `0.96` (the `x = +2` case
correctly gives `0.96`). `posterior_mean_exp`, `point_exp`, and
`generalized_binary` are unaffected (they use the `[0, inf)` region, where the
flip compensates).

**Fix:** keep `mean` signed and undo the flip on the inner first moment. Adds
regression tests (quadrature ground truth, reflection symmetry,
`E[X^2] >= E[X]^2`). The existing edge-case test never exercised a negative mean.

**Merge order:** independent of #66, #67, #68, #69; merge in any order.



