### PR TITLE
Fix spike+exp posterior second-moment guard

### DIFF
--- a/src/cebmf_torch/utils/posterior.py
+++ b/src/cebmf_torch/utils/posterior.py
@@ -161,7 +161,11 @@ def posterior_mean_exp(
     r_exp = post_assign[:, 1:]  # (J, K-1) — responsibilities of the Exp components
     post_mean = (r_exp * e1).sum(dim=1)  # (J,)
     post_mean2 = (r_exp * e2).sum(dim=1)  # (J,)
-    post_mean2 = torch.maximum(post_mean2, post_mean)  # original guard
+    # Numerical floor: E[theta^2] >= E[theta]^2 holds exactly (the exp
+    # responsibilities sum to <= 1), so this only catches float error. Guarding
+    # against ``post_mean`` (rather than ``post_mean**2``) wrongly inflated the
+    # second moment whenever post_mean < 1.
+    post_mean2 = torch.maximum(post_mean2, post_mean.pow(2))
 
     # Infinite-s rows: collapse to the *prior* mixture mean / second moment.
     # With s = inf the data contributes no information, so the posterior

--- a/src/cebmf_torch/utils/posterior.py
+++ b/src/cebmf_torch/utils/posterior.py
@@ -161,9 +161,9 @@ def posterior_mean_exp(
     r_exp = post_assign[:, 1:]  # (J, K-1) — responsibilities of the Exp components
     post_mean = (r_exp * e1).sum(dim=1)  # (J,)
     post_mean2 = (r_exp * e2).sum(dim=1)  # (J,)
-    # Numerical floor: E[theta^2] >= E[theta]^2 holds exactly (the exp
-    # responsibilities sum to <= 1), so this only catches float error. Guarding
-    # against ``post_mean`` (rather than ``post_mean**2``) wrongly inflated the
+    # Numerical floor: E[theta^2] >= E[theta]^2 by variance non-negativity
+    # (Jensen), so this only catches float error. Guarding against
+    # ``post_mean`` (rather than ``post_mean**2``) wrongly inflated the
     # second moment whenever post_mean < 1.
     post_mean2 = torch.maximum(post_mean2, post_mean.pow(2))
 

--- a/tests/test_posterior_mean_exp_second_moment.py
+++ b/tests/test_posterior_mean_exp_second_moment.py
@@ -1,0 +1,60 @@
+"""Regression tests for the spike+exponential posterior second moment.
+
+The guard ``post_mean2 = maximum(post_mean2, post_mean)`` inflated the second
+moment whenever ``post_mean < 1`` (the common case): since E[theta^2] >=
+E[theta]^2 always holds, the correct numerical floor is ``post_mean**2``.
+"""
+
+import math
+
+import numpy as np
+import torch
+
+from cebmf_torch.utils.posterior import posterior_mean_exp
+
+CPU = torch.device("cpu")
+
+
+def _brute_exp_posterior(x, s, pi, scale, n=400_001):
+    """Brute-force E[theta], E[theta^2] under pi0*delta_0 + sum pi_k Exp(1/scale_k)."""
+    theta = np.linspace(0.0, max(scale) * 40 + 20 * s, n)
+    rates = 1.0 / np.asarray(scale[1:])
+    slab_pdf = np.zeros_like(theta)
+    for w, a in zip(pi[1:], rates):
+        slab_pdf += w * a * np.exp(-a * theta)
+    lik = np.exp(-0.5 * ((x - theta) / s) ** 2) / (s * math.sqrt(2 * math.pi))
+    spike = pi[0] * (np.exp(-0.5 * (x / s) ** 2) / (s * math.sqrt(2 * math.pi)))
+    unnorm = slab_pdf * lik
+    z = np.trapz(unnorm, theta) + spike
+    m1 = np.trapz(theta * unnorm, theta) / z
+    m2 = np.trapz(theta * theta * unnorm, theta) / z
+    return m1, m2
+
+
+def test_second_moment_not_inflated_matches_brute_force():
+    pi = [0.2, 0.4, 0.3, 0.1]
+    scale = [0.0, 0.5, 1.0, 2.0]
+    xs = np.linspace(0.1, 0.9, 8)  # small effects -> post_mean < 1
+    bh = torch.tensor(xs, dtype=torch.float64, device=CPU)
+    se = torch.ones(8, dtype=torch.float64, device=CPU)
+    out = posterior_mean_exp(
+        bh, se, torch.log(torch.tensor(pi, dtype=torch.float64, device=CPU)),
+        torch.tensor(scale, dtype=torch.float64, device=CPU),
+    )
+    for j, x in enumerate(xs):
+        _, m2_ref = _brute_exp_posterior(float(x), 1.0, pi, scale)
+        assert abs(float(out.post_mean2[j]) - m2_ref) < 5e-3, (
+            f"x={x}: got {float(out.post_mean2[j])}, expected {m2_ref}"
+        )
+
+
+def test_second_moment_at_least_first_moment_squared():
+    pi = [0.5, 0.3, 0.2]
+    scale = [0.0, 0.5, 1.5]
+    bh = torch.linspace(-1.0, 1.0, 11, dtype=torch.float64, device=CPU)
+    se = torch.ones(11, dtype=torch.float64, device=CPU)
+    out = posterior_mean_exp(
+        bh, se, torch.log(torch.tensor(pi, dtype=torch.float64, device=CPU)),
+        torch.tensor(scale, dtype=torch.float64, device=CPU),
+    )
+    assert torch.all(out.post_mean2 >= out.post_mean.pow(2) - 1e-9)

--- a/tests/test_posterior_mean_exp_second_moment.py
+++ b/tests/test_posterior_mean_exp_second_moment.py
@@ -25,9 +25,9 @@ def _brute_exp_posterior(x, s, pi, scale, n=400_001):
     lik = np.exp(-0.5 * ((x - theta) / s) ** 2) / (s * math.sqrt(2 * math.pi))
     spike = pi[0] * (np.exp(-0.5 * (x / s) ** 2) / (s * math.sqrt(2 * math.pi)))
     unnorm = slab_pdf * lik
-    z = np.trapz(unnorm, theta) + spike
-    m1 = np.trapz(theta * unnorm, theta) / z
-    m2 = np.trapz(theta * theta * unnorm, theta) / z
+    z = np.trapezoid(unnorm, theta) + spike
+    m1 = np.trapezoid(theta * unnorm, theta) / z
+    m2 = np.trapezoid(theta * theta * unnorm, theta) / z
     return m1, m2
 
 

--- a/tests/test_posterior_mean_exp_second_moment.py
+++ b/tests/test_posterior_mean_exp_second_moment.py
@@ -20,7 +20,7 @@ def _brute_exp_posterior(x, s, pi, scale, n=400_001):
     theta = np.linspace(0.0, max(scale) * 40 + 20 * s, n)
     rates = 1.0 / np.asarray(scale[1:])
     slab_pdf = np.zeros_like(theta)
-    for w, a in zip(pi[1:], rates):
+    for w, a in zip(pi[1:], rates, strict=False):
         slab_pdf += w * a * np.exp(-a * theta)
     lik = np.exp(-0.5 * ((x - theta) / s) ** 2) / (s * math.sqrt(2 * math.pi))
     spike = pi[0] * (np.exp(-0.5 * (x / s) ** 2) / (s * math.sqrt(2 * math.pi)))
@@ -38,7 +38,9 @@ def test_second_moment_not_inflated_matches_brute_force():
     bh = torch.tensor(xs, dtype=torch.float64, device=CPU)
     se = torch.ones(8, dtype=torch.float64, device=CPU)
     out = posterior_mean_exp(
-        bh, se, torch.log(torch.tensor(pi, dtype=torch.float64, device=CPU)),
+        bh,
+        se,
+        torch.log(torch.tensor(pi, dtype=torch.float64, device=CPU)),
         torch.tensor(scale, dtype=torch.float64, device=CPU),
     )
     for j, x in enumerate(xs):
@@ -54,7 +56,9 @@ def test_second_moment_at_least_first_moment_squared():
     bh = torch.linspace(-1.0, 1.0, 11, dtype=torch.float64, device=CPU)
     se = torch.ones(11, dtype=torch.float64, device=CPU)
     out = posterior_mean_exp(
-        bh, se, torch.log(torch.tensor(pi, dtype=torch.float64, device=CPU)),
+        bh,
+        se,
+        torch.log(torch.tensor(pi, dtype=torch.float64, device=CPU)),
         torch.tensor(scale, dtype=torch.float64, device=CPU),
     )
     assert torch.all(out.post_mean2 >= out.post_mean.pow(2) - 1e-9)


### PR DESCRIPTION
**Impact: must fix (correctness).** Posterior second moment over-estimated by up
to ~19%.

`posterior_mean_exp` floored the second moment at `post_mean` instead of
`post_mean**2`. Since `E[theta^2] >= E[theta]^2` always holds for this
posterior, the guard only ever fired as a wrong-way inflation when
`post_mean < 1`, over-estimating `E[theta^2]` by up to ~19%.

Uses `post_mean**2`, matching the already-correct guard in
`ebnm/point_exp.py`. Adds tests against a brute-force spike+Exp posterior and
the variance-nonnegativity invariant.

**Merge order:** independent of #65, #67, #68, #69; merge in any order.



