### PR TITLE
Stabilize CASH loss with log-space reduction

### DIFF
--- a/src/cebmf_torch/cebnm/cash_solver.py
+++ b/src/cebmf_torch/cebnm/cash_solver.py
@@ -68,10 +68,12 @@ class CashNet(nn.Module):
 
 # Custom loss function
 def pen_loglik_loss(pred_pi, marginal_log_lik, penalty=1.5, epsilon=1e-10):
-    # log sum_k pi_k * exp(mll_k) computed in log-space. The previous code
-    # exponentiated marginal_log_lik directly, which overflows to inf in float32
-    # for small standard errors (mll can exceed ~88), making the loss inf/NaN.
-    # This matches the logsumexp the EMDN / spiked-EMDN solvers already use.
+    # log sum_k pi_k * exp(mll_k), reduced in log-space. The previous code
+    # exponentiated marginal_log_lik directly; exp() is unnecessary here and
+    # overflows float32 to inf for mll > ~88. marginal_log_lik is only clamped
+    # upstream to [-1e5, 1e5], so any such value would turn the loss into
+    # inf/NaN. logsumexp avoids exp() entirely and matches the reduction the
+    # EMDN / spiked-EMDN solvers already use.
     log_pi = torch.log(torch.clamp(pred_pi, min=epsilon))  # (B, K)
     first_sum = torch.logsumexp(log_pi + marginal_log_lik, dim=1).sum()  # scalar
 

--- a/src/cebmf_torch/cebnm/cash_solver.py
+++ b/src/cebmf_torch/cebnm/cash_solver.py
@@ -68,10 +68,12 @@ class CashNet(nn.Module):
 
 # Custom loss function
 def pen_loglik_loss(pred_pi, marginal_log_lik, penalty=1.5, epsilon=1e-10):
-    L_batch = torch.exp(marginal_log_lik)  # (B, K)
-    inner_sum = torch.sum(pred_pi * L_batch, dim=1)  # (B,)
-    inner_sum = torch.clamp(inner_sum, min=epsilon)
-    first_sum = torch.sum(torch.log(inner_sum))  # scalar
+    # log sum_k pi_k * exp(mll_k) computed in log-space. The previous code
+    # exponentiated marginal_log_lik directly, which overflows to inf in float32
+    # for small standard errors (mll can exceed ~88), making the loss inf/NaN.
+    # This matches the logsumexp the EMDN / spiked-EMDN solvers already use.
+    log_pi = torch.log(torch.clamp(pred_pi, min=epsilon))  # (B, K)
+    first_sum = torch.logsumexp(log_pi + marginal_log_lik, dim=1).sum()  # scalar
 
     if penalty > 1:
         # penalize per-gene spike probability (Dirichlet-like prior on component 0)

--- a/tests/test_cash_loss_stable.py
+++ b/tests/test_cash_loss_stable.py
@@ -1,0 +1,45 @@
+"""Regression tests for the CASH penalized-log-likelihood loss.
+
+The loss previously exponentiated the (clamped, possibly large) convolved
+log-likelihoods before summing, overflowing to inf/NaN in float32 for small
+standard errors. It now reduces in log-space via logsumexp.
+"""
+
+import math
+
+import torch
+
+from cebmf_torch.cebnm.cash_solver import pen_loglik_loss
+
+
+def test_loss_finite_for_large_log_likelihoods():
+    # Small SEs push convolved log-densities well past the float32 exp() limit.
+    torch.manual_seed(0)
+    B, K = 16, 5
+    pred_pi = torch.softmax(torch.randn(B, K), dim=1)
+    marginal_log_lik = torch.full((B, K), 90.0)  # exp(90) overflows float32
+    loss = pen_loglik_loss(pred_pi, marginal_log_lik, penalty=1.5)
+    assert torch.isfinite(loss), loss
+
+
+def test_loss_matches_naive_in_safe_regime():
+    # Where exp() does not overflow, the new loss equals the original formula.
+    torch.manual_seed(1)
+    B, K = 8, 4
+    pred_pi = torch.softmax(torch.randn(B, K), dim=1)
+    mll = torch.randn(B, K) * 0.5  # small -> no overflow
+    eps = 1e-10
+    naive_first = torch.log(torch.clamp((pred_pi * torch.exp(mll)).sum(1), min=eps)).sum()
+    naive = -(naive_first + (1.5 - 1) * torch.log(torch.clamp(pred_pi[:, 0], min=eps)).sum())
+    got = pen_loglik_loss(pred_pi, mll, penalty=1.5)
+    assert abs(float(got) - float(naive)) < 1e-4, (float(got), float(naive))
+
+
+def test_loss_is_differentiable():
+    B, K = 6, 3
+    logits = torch.randn(B, K, requires_grad=True)
+    pred_pi = torch.softmax(logits, dim=1)
+    mll = torch.full((B, K), 50.0)
+    loss = pen_loglik_loss(pred_pi, mll, penalty=2.0)
+    loss.backward()
+    assert logits.grad is not None and torch.isfinite(logits.grad).all()

--- a/tests/test_cash_loss_stable.py
+++ b/tests/test_cash_loss_stable.py
@@ -5,8 +5,6 @@ log-likelihoods before summing, overflowing to inf/NaN in float32 for small
 standard errors. It now reduces in log-space via logsumexp.
 """
 
-import math
-
 import torch
 
 from cebmf_torch.cebnm.cash_solver import pen_loglik_loss


### PR DESCRIPTION
**Impact: recommended (numerical robustness).** No behavior change in the safe
regime; removes a latent `inf`/`NaN` path.

`pen_loglik_loss` exponentiated the convolved log-likelihoods before summing
over mixture components. Those log-densities are clamped to `[-1e5, 1e5]`
upstream, so any value past the float32 `exp()` limit (~88) sends `exp()` to
`inf` and makes the loss `inf`/`NaN`. `exp()` is unnecessary here anyway.

Reduces in log-space via `logsumexp(log_pi + marginal_log_lik)`, matching the
EMDN and spiked-EMDN solvers. Adds tests for finiteness under large inputs,
equivalence in the safe regime, and differentiability.

**Merge order:** independent of #65, #66, #68, #69; merge in any order.



