### PR TITLE
Remove dead code

### DIFF
--- a/src/cebmf_torch/cebmf/cebmf.py
+++ b/src/cebmf_torch/cebmf/cebmf.py
@@ -451,10 +451,6 @@ class cEBMF:
         self._prune_indices(to_drop_sorted)
 
     @torch.no_grad()
-    def _update_fitted_value(self):
-        self.Y_fit = self.L @ self.F.T
-
-    @torch.no_grad()
     def _expected_residuals_squared(self):
         """
         E[(Y - sum_k L_k F_k)^2] on observed entries.
@@ -602,14 +598,6 @@ class cEBMF:
         view = (-1, 1) if dim == 1 else (1, -1)
         self.tau_map = tau.view(*view).expand(self.N, self.P)  # (N,P)
         self.tau = self.tau_map  # downstream uses elementwise in structured noise
-
-    @torch.no_grad()
-    def _partial_residual_masked(self, k: int) -> Tensor:
-        # Rk for observed entries only
-        recon = self.L @ self.F.T
-        k_contrib = torch.outer(self.L[:, k], self.F[:, k])
-        Rk = (self.Y0 - (recon - k_contrib)) * self.mask
-        return Rk
 
     @torch.no_grad()
     def _should_prune_factor(self, k: int) -> bool:

--- a/src/cebmf_torch/cebmf/cebmf.py
+++ b/src/cebmf_torch/cebmf/cebmf.py
@@ -451,6 +451,10 @@ class cEBMF:
         self._prune_indices(to_drop_sorted)
 
     @torch.no_grad()
+    def _update_fitted_value(self):
+        self.Y_fit = self.L @ self.F.T
+
+    @torch.no_grad()
     def _expected_residuals_squared(self):
         """
         E[(Y - sum_k L_k F_k)^2] on observed entries.

--- a/src/cebmf_torch/utils/maths.py
+++ b/src/cebmf_torch/utils/maths.py
@@ -4,7 +4,6 @@ import torch
 from torch import Tensor
 
 _TWOPI = 2.0 * math.pi
-_SQRT_2PI = math.sqrt(_TWOPI)
 _EPS = 1e-12
 _LOG_2PI = math.log(_TWOPI)
 _LOG_SQRT_2PI = 0.5 * _LOG_2PI
@@ -45,40 +44,6 @@ def log_norm_pdf(x: Tensor, loc: Tensor, scale: Tensor) -> Tensor:
 def _logcdf_normal(z: Tensor) -> Tensor:
     """Numerically-stable log Φ(z) (standard normal CDF). Wraps torch.special.log_ndtr."""
     return torch.special.log_ndtr(z)
-
-
-def norm_cdf(x: Tensor) -> Tensor:
-    """
-    Compute the standard normal cumulative distribution function (CDF).
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        Input tensor.
-
-    Returns
-    -------
-    torch.Tensor
-        CDF evaluated at x.
-    """
-    return torch.distributions.Normal(_like(x, 0.0), _like(x, 1.0)).cdf(x)
-
-
-def norm_pdf(x: Tensor) -> Tensor:
-    """
-    Compute the standard normal probability density function (PDF).
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        Input tensor.
-
-    Returns
-    -------
-    torch.Tensor
-        PDF evaluated at x.
-    """
-    return torch.exp(-0.5 * x * x) / _like(x, _SQRT_2PI)
 
 
 def logsumexp(x: Tensor, dim: int = -1, keepdim: bool = False) -> Tensor:
@@ -197,25 +162,6 @@ def logscale_sub(logx: torch.Tensor, logy: torch.Tensor) -> torch.Tensor:
     """
     max_log = torch.maximum(logx, logy)
     return max_log + torch.log(torch.exp(logx - max_log) - torch.exp(logy - max_log))
-
-
-def logscale_add(logx: Tensor, logy: Tensor) -> Tensor:
-    """
-    Compute log(exp(logx) + exp(logy)) in a numerically stable way.
-
-    Parameters
-    ----------
-    logx : torch.Tensor
-        Logarithm of x.
-    logy : torch.Tensor
-        Logarithm of y.
-
-    Returns
-    -------
-    torch.Tensor
-        Logarithm of (exp(logx) + exp(logy)).
-    """
-    return torch.logaddexp(logx, logy)
 
 
 def do_truncnorm_argchecks(a: torch.Tensor, b: torch.Tensor):

--- a/src/cebmf_torch/utils/posterior.py
+++ b/src/cebmf_torch/utils/posterior.py
@@ -26,58 +26,6 @@ class PosteriorMean:
 
 
 @torch.no_grad()
-def wpost_exp(x: torch.Tensor, s: torch.Tensor, w: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    """
-    Compute responsibilities for a spike+exponential mixture prior on (theta >= 0).
-
-    Parameters
-    ----------
-    x : torch.Tensor
-        Observed betahat (scalar tensor or shape ()).
-    s : torch.Tensor
-        Standard error (scalar tensor or shape ()).
-    w : torch.Tensor
-        (K,) mixture weights (sum to 1), w[0] for spike at 0, w[1:] for Exp scales.
-    scale : torch.Tensor
-        (K,) with scale[0]=0 for spike, scale[1:]>0 as Exp scales (rate = 1/scale).
-
-    Returns
-    -------
-    torch.Tensor
-        (K,) posterior responsibilities.
-    """
-    # ensure tensors stay on the same device/dtype
-    x = torch.as_tensor(x)
-    s = torch.as_tensor(s, dtype=x.dtype, device=x.device)
-    w = torch.as_tensor(w, dtype=x.dtype, device=x.device)
-    scale = torch.as_tensor(scale, dtype=x.dtype, device=x.device)
-
-    # spike log-lik
-    lf = _logpdf_normal(x, torch.as_tensor(0.0, dtype=x.dtype, device=x.device), s)
-
-    # exp components
-    a = 1.0 / scale[1:]  # rates
-    lg = torch.log(a) + 0.5 * (s * a).pow(2) - a * x + _logcdf_normal(x / s - s * a)
-
-    log_prob = torch.empty_like(scale)
-    log_prob[0] = lf
-    log_prob[1:] = lg
-
-    # posterior responsibilities with log-sum-exp stabilization
-    bmax = torch.max(log_prob)
-    num = w * torch.exp(log_prob - bmax)
-    r = num / torch.clamp(num.sum(), min=1e-300)
-
-    # Degenerate case: w[0] >= 1 means all mass on the spike. Replace with the
-    # one-hot response, branchless to avoid `if torch.all(...):` host sync.
-    spike_only = w[0] >= 1.0
-    r_spike = torch.zeros_like(scale)
-    r_spike[0] = 1.0
-    r = torch.where(spike_only, r_spike, r)
-    return r
-
-
-@torch.no_grad()
 def posterior_mean_exp(
     betahat: torch.Tensor,
     sebetahat: torch.Tensor,

--- a/tests/test_gpu_residency_improvements.py
+++ b/tests/test_gpu_residency_improvements.py
@@ -212,33 +212,6 @@ def test_my_etruncnorm_no_zero_sd_path_unchanged():
     assert torch.isfinite(out).all()
 
 
-def test_wpost_exp_spike_only_branchless():
-    """w[0]==1 must still give one-hot spike response."""
-    from cebmf_torch.utils.posterior import wpost_exp
-
-    x = torch.tensor(0.1)
-    s = torch.tensor(0.5)
-    w = torch.tensor([1.0, 0.0, 0.0])
-    scale = torch.tensor([0.0, 1.0, 2.0])
-    r = wpost_exp(x, s, w, scale)
-    expected = torch.tensor([1.0, 0.0, 0.0])
-    assert torch.allclose(r, expected, atol=1e-6)
-
-
-def test_wpost_exp_normal_case():
-    """Mixed weights should produce a normal distribution of responsibility."""
-    from cebmf_torch.utils.posterior import wpost_exp
-
-    x = torch.tensor(2.0)
-    s = torch.tensor(0.5)
-    w = torch.tensor([0.3, 0.5, 0.2])
-    scale = torch.tensor([0.0, 1.0, 2.0])
-    r = wpost_exp(x, s, w, scale)
-    assert r.shape == (3,)
-    assert torch.allclose(r.sum(), torch.tensor(1.0), atol=1e-5)
-    assert (r >= 0).all() and (r <= 1).all()
-
-
 def test_normal_means_loglik_branchless_invalid_inputs():
     """All-invalid input must give a finite (zero) result via the branchless path."""
     from cebmf_torch.cebmf.cebmf import normal_means_loglik


### PR DESCRIPTION
**Impact: cosmetic (dead-code removal, no behavior change).**

(YA: I am really not sure we want this! - was suggested by an LLM review)

Removes functions with no references in `src/`, `tests/`, `examples/`, or
`docs/`:

- `utils/posterior.py`: `wpost_exp` (and its two tests). Superseded by the
  vectorized `posterior_mean_exp`.
- `utils/maths.py`: `norm_cdf`, `norm_pdf`, `logscale_add`, and the now-unused
  `_SQRT_2PI`.
- `cebmf/cebmf.py`: `_partial_residual_masked` (no references anywhere).

Intentionally kept: `log_norm_pdf` (a documented backward-compat alias with an
explicit guard test), and `_update_fitted_value` with its `Y_fit` attribute.
The published example notebook `examples/Tiled-clustering model.ipynb` (listed
in `docs/source/examples.rst`) calls `_update_fitted_value()` and reads
`.Y_fit`, and this method is the only writer of `self.Y_fit`.

**Merge order:** independent of #65, #66, #67, #69; merge in any order. This PR
also removes `wpost_exp`, the last inline copy of the Exp-prior marginal that
#69 consolidates.




