### PR TITLE
Consolidate convolution helpers (single source of truth)

### DIFF
--- a/src/cebmf_torch/ebnm/point_exp.py
+++ b/src/cebmf_torch/ebnm/point_exp.py
@@ -4,7 +4,12 @@ import math
 import torch
 from torch import Tensor
 
-from cebmf_torch.utils.maths import _LOG_SQRT_2PI, logPhi, my_e2truncnorm, my_etruncnorm
+from cebmf_torch.utils.maths import (
+    _LOG_SQRT_2PI,
+    logg_exp_convolved_with_normal,
+    my_e2truncnorm,
+    my_etruncnorm,
+)
 
 
 def _const_like(x: Tensor, val) -> Tensor:
@@ -25,8 +30,7 @@ def _loglik_spike(xc: Tensor, s: Tensor) -> Tensor:
 
 def _loglik_exp_convolved(xc: Tensor, s: Tensor, a: Tensor) -> Tensor:
     # lg = log a + (s a)^2 / 2 - a * xc + log Φ(xc/s - s a), θ_c ≥ 0
-    z = xc / s - s * a
-    return torch.log(a) + _const_like(xc, 0.5) * (s * a) ** 2 - a * xc + logPhi(z)
+    return logg_exp_convolved_with_normal(xc, s, a)
 
 
 def _posterior_moments_exp_branch(xc: Tensor, s: Tensor, a: Tensor) -> tuple[Tensor, Tensor]:

--- a/src/cebmf_torch/ebnm/point_laplace.py
+++ b/src/cebmf_torch/ebnm/point_laplace.py
@@ -17,12 +17,16 @@ def _const_like(x: Tensor, val) -> Tensor:
     return torch.as_tensor(val, device=x.device, dtype=x.dtype)
 
 
-def logg_laplace_convolved_with_normal(x: Tensor, s: Tensor, a: Tensor) -> Tensor:
+def _laplace_slab_terms(x: Tensor, s: Tensor, a: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+    """Shared terms for the Laplace ⊗ Normal slab marginal.
+
+    Returns ``(lg, lg1, lsum)`` where ``lg`` is the slab log-density and
+    ``lg1``/``lsum`` are the positive-branch log-term and the log-sum of the
+    two sign branches. The posterior computation reuses ``lg1``/``lsum`` to
+    form the within-slab sign-mixture weight ``lam = exp(lg1 - lsum)``.
+
+    Assumes x, s, a already on the correct device/dtype; s already clamped.
     """
-    log (Laplace(0, rate=a) ⊗ Normal(0, s^2)) at x.
-    = log(a/2) + 0.5*(s a)^2 + log( Φ((x - s^2 a)/s) e^{-a x} + Φ(-(x + s^2 a)/s) e^{a x} )
-    """
-    # assume x, s, a already on correct device/dtype; s already clamped outside
     z1 = (x - (s * s) * a) / s
     z2 = -(x + (s * s) * a) / s
     lg1 = -a * x + logPhi(z1)
@@ -30,7 +34,17 @@ def logg_laplace_convolved_with_normal(x: Tensor, s: Tensor, a: Tensor) -> Tenso
     lsum = torch.logaddexp(lg1, lg2)
     half = torch.tensor(0.5, device=x.device, dtype=x.dtype)
     two = torch.tensor(2.0, device=x.device, dtype=x.dtype)
-    return safe_log(a / two) + half * (s * a) ** 2 + lsum
+    lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
+    return lg, lg1, lsum
+
+
+def logg_laplace_convolved_with_normal(x: Tensor, s: Tensor, a: Tensor) -> Tensor:
+    """
+    log (Laplace(0, rate=a) ⊗ Normal(0, s^2)) at x.
+    = log(a/2) + 0.5*(s a)^2 + log( Φ((x - s^2 a)/s) e^{-a x} + Φ(-(x + s^2 a)/s) e^{a x} )
+    """
+    lg, _, _ = _laplace_slab_terms(x, s, a)
+    return lg
 
 
 @dataclass
@@ -130,13 +144,8 @@ def ebnm_point_laplace(
             # spike log-lik
             lf = -(half * (xc / s) ** 2) - log_s - c_norm
 
-            # slab log-lik (fused helper)
-            z1 = (xc - s2 * a) / s
-            z2 = -(xc + s2 * a) / s
-            lg1 = -a * xc + logPhi(z1)
-            lg2 = a * xc + logPhi(z2)
-            lsum = torch.logaddexp(lg1, lg2)
-            lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
+            # slab log-lik
+            lg, _, _ = _laplace_slab_terms(xc, s, a)
 
             llik = torch.logaddexp(torch.log1p(-w) + lf, torch.log(w) + lg).sum()
 
@@ -171,13 +180,8 @@ def ebnm_point_laplace(
             # spike log-lik (reuses log_s, c_norm)
             lf = -(half * (xc / s) ** 2) - log_s - c_norm
 
-            # slab log-lik (inline for speed)
-            z1 = (xc - s2 * a) / s
-            z2 = -(xc + s2 * a) / s
-            lg1 = -a * xc + logPhi(z1)
-            lg2 = a * xc + logPhi(z2)
-            lsum = torch.logaddexp(lg1, lg2)
-            lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
+            # slab log-lik
+            lg, _, _ = _laplace_slab_terms(xc, s, a)
 
             llik = torch.logaddexp(torch.log1p(-w) + lf, torch.log(w) + lg).sum()
 
@@ -227,12 +231,7 @@ def ebnm_point_laplace(
         lf = -(half * (xc / s) ** 2) - log_s - c_norm
 
         # slab
-        z1 = (xc - s2 * a) / s
-        z2 = -(xc + s2 * a) / s
-        lg1 = -a * xc + logPhi(z1)
-        lg2 = a * xc + logPhi(z2)
-        lsum = torch.logaddexp(lg1, lg2)
-        lg = safe_log(a / two) + half * (s * a) ** 2 + lsum
+        lg, lg1, lsum = _laplace_slab_terms(xc, s, a)
 
         # posterior inclusion prob (slab)
         log_num = torch.log(w) + lg

--- a/src/cebmf_torch/utils/distribution_operation.py
+++ b/src/cebmf_torch/utils/distribution_operation.py
@@ -5,7 +5,7 @@ import torch
 # Canonical normal helpers live in utils/maths.py; re-exported here so existing
 # imports (`from cebmf_torch.utils.distribution_operation import _logpdf_normal`)
 # keep working.
-from .maths import _logcdf_normal, _logpdf_normal  # noqa: F401
+from .maths import _logcdf_normal, _logpdf_normal, logg_exp_convolved_with_normal  # noqa: F401
 
 
 def _const_like(c, ref: torch.Tensor) -> torch.Tensor:
@@ -145,7 +145,7 @@ def convolved_logpdf_exp_torch(
     x = betahat.unsqueeze(1)  # (J,1)
     a = rate.unsqueeze(0)  # (1,K-1)
 
-    lg = torch.log(a) + 0.5 * (s * a).pow(2) - a * x + _logcdf_normal(x / s - s * a)  # (J,K-1)
+    lg = logg_exp_convolved_with_normal(x, s, a)  # (J,K-1)
 
     # Concatenate first column
     L = torch.empty((J, K), dtype=betahat.dtype, device=betahat.device)

--- a/src/cebmf_torch/utils/maths.py
+++ b/src/cebmf_torch/utils/maths.py
@@ -48,12 +48,12 @@ def _logcdf_normal(z: Tensor) -> Tensor:
 
 
 def logg_exp_convolved_with_normal(x: Tensor, s: Tensor, rate: Tensor) -> Tensor:
-    """log( Exp(rate) ⊗ Normal(0, s^2) ) evaluated at ``x``, for theta >= 0.
+    r"""log density of Exp(rate) convolved with Normal(0, s^2) at ``x``, for theta >= 0.
 
-    = log(rate) + 0.5*(s*rate)^2 - rate*x + log Φ(x/s - s*rate)
+    = log(rate) + 0.5*(s*rate)^2 - rate*x + log \Phi(x/s - s*rate)
 
     Inputs broadcast against one another, so ``x``/``s`` may be ``(J, 1)`` and
-    ``rate`` ``(1, K)`` (or any broadcast-compatible shapes). This is the single
+    ``rate`` ``(1, K-1)`` (or any broadcast-compatible shapes). This is the single
     source of truth for the Exp-prior marginal log-density; callers must ensure
     ``s > 0`` and ``rate > 0`` (the spike component is handled separately).
     """

--- a/src/cebmf_torch/utils/maths.py
+++ b/src/cebmf_torch/utils/maths.py
@@ -47,6 +47,19 @@ def _logcdf_normal(z: Tensor) -> Tensor:
     return torch.special.log_ndtr(z)
 
 
+def logg_exp_convolved_with_normal(x: Tensor, s: Tensor, rate: Tensor) -> Tensor:
+    """log( Exp(rate) ⊗ Normal(0, s^2) ) evaluated at ``x``, for theta >= 0.
+
+    = log(rate) + 0.5*(s*rate)^2 - rate*x + log Φ(x/s - s*rate)
+
+    Inputs broadcast against one another, so ``x``/``s`` may be ``(J, 1)`` and
+    ``rate`` ``(1, K)`` (or any broadcast-compatible shapes). This is the single
+    source of truth for the Exp-prior marginal log-density; callers must ensure
+    ``s > 0`` and ``rate > 0`` (the spike component is handled separately).
+    """
+    return torch.log(rate) + 0.5 * (s * rate).pow(2) - rate * x + _logcdf_normal(x / s - s * rate)
+
+
 def norm_cdf(x: Tensor) -> Tensor:
     """
     Compute the standard normal cumulative distribution function (CDF).
@@ -174,7 +187,7 @@ def logPhi(z: torch.Tensor) -> torch.Tensor:
     torch.Tensor
         Log CDF evaluated at z.
     """
-    return torch.special.log_ndtr(z)
+    return _logcdf_normal(z)
 
 
 def logscale_sub(logx: torch.Tensor, logy: torch.Tensor) -> torch.Tensor:

--- a/src/cebmf_torch/utils/maths.py
+++ b/src/cebmf_torch/utils/maths.py
@@ -47,19 +47,6 @@ def _logcdf_normal(z: Tensor) -> Tensor:
     return torch.special.log_ndtr(z)
 
 
-def logg_exp_convolved_with_normal(x: Tensor, s: Tensor, rate: Tensor) -> Tensor:
-    r"""log density of Exp(rate) convolved with Normal(0, s^2) at ``x``, for theta >= 0.
-
-    = log(rate) + 0.5*(s*rate)^2 - rate*x + log \Phi(x/s - s*rate)
-
-    Inputs broadcast against one another, so ``x``/``s`` may be ``(J, 1)`` and
-    ``rate`` ``(1, K-1)`` (or any broadcast-compatible shapes). This is the single
-    source of truth for the Exp-prior marginal log-density; callers must ensure
-    ``s > 0`` and ``rate > 0`` (the spike component is handled separately).
-    """
-    return torch.log(rate) + 0.5 * (s * rate).pow(2) - rate * x + _logcdf_normal(x / s - s * rate)
-
-
 def norm_cdf(x: Tensor) -> Tensor:
     """
     Compute the standard normal cumulative distribution function (CDF).
@@ -113,6 +100,19 @@ def logsumexp(x: Tensor, dim: int = -1, keepdim: bool = False) -> Tensor:
         Result of log-sum-exp operation.
     """
     return torch.logsumexp(x, dim=dim, keepdim=keepdim)
+
+
+def logg_exp_convolved_with_normal(x: Tensor, s: Tensor, rate: Tensor) -> Tensor:
+    r"""log density of Exp(rate) convolved with Normal(0, s^2) at ``x``, for theta >= 0.
+
+    = log(rate) + 0.5*(s*rate)^2 - rate*x + log \Phi(x/s - s*rate)
+
+    Inputs broadcast against one another, so ``x``/``s`` may be ``(J, 1)`` and
+    ``rate`` ``(1, K-1)`` (or any broadcast-compatible shapes). This is the single
+    source of truth for the Exp-prior marginal log-density; callers must ensure
+    ``s > 0`` and ``rate > 0`` (the spike component is handled separately).
+    """
+    return torch.log(rate) + 0.5 * (s * rate).pow(2) - rate * x + _logcdf_normal(x / s - s * rate)
 
 
 def safe_log(x: Tensor, eps: float = _EPS) -> Tensor:

--- a/src/cebmf_torch/utils/posterior.py
+++ b/src/cebmf_torch/utils/posterior.py
@@ -2,7 +2,13 @@ import torch
 
 # Re-export the canonical normal-density helpers so existing imports keep working.
 # The single source of truth lives in utils/maths.py.
-from .maths import _logcdf_normal, _logpdf_normal, my_e2truncnorm, my_etruncnorm  # noqa: F401
+from .maths import (  # noqa: F401
+    _logcdf_normal,
+    _logpdf_normal,
+    logg_exp_convolved_with_normal,
+    my_e2truncnorm,
+    my_etruncnorm,
+)
 
 
 class PosteriorMean:
@@ -135,9 +141,7 @@ def posterior_mean_exp(
     a = 1.0 / scale[1:]  # (K-1,) — rates of the Exp components
     a_row = a.unsqueeze(0)  # (1, K-1)
 
-    lg = (
-        torch.log(a_row) + 0.5 * (s_col * a_row).pow(2) - a_row * x_col + _logcdf_normal(x_col / s_col - s_col * a_row)
-    )  # (J, K-1)
+    lg = logg_exp_convolved_with_normal(x_col, s_col, a_row)  # (J, K-1)
 
     log_prob = torch.cat([lf.unsqueeze(1), lg], dim=1)  # (J, K)
 

--- a/tests/test_logg_laplace_convolved.py
+++ b/tests/test_logg_laplace_convolved.py
@@ -1,0 +1,58 @@
+"""Regression test for the public Laplace-convolved-with-normal log density.
+
+``logg_laplace_convolved_with_normal`` is the documented single-source closed
+form for log( Laplace(0, rate=a) (x) Normal(0, s^2) ). After the consolidation
+refactor it delegates to ``_laplace_slab_terms``; this test pins it to an
+independent brute-force convolution so the public helper keeps a guard of its
+own (and exercises the otherwise-uncalled wrapper).
+"""
+
+import math
+
+import numpy as np
+import torch
+
+from cebmf_torch.ebnm.point_laplace import (
+    _laplace_slab_terms,
+    logg_laplace_convolved_with_normal,
+)
+
+CPU = torch.device("cpu")
+
+
+def _t(v):
+    return torch.tensor(float(v), dtype=torch.float64, device=CPU)
+
+
+def _brute_logg_laplace(x, s, a, n=400_001):
+    """log integral of (a/2) e^{-a|theta|} * Normal(x-theta; 0, s^2) d theta."""
+    span = 40.0 * s + 40.0 / a
+    theta = np.linspace(x - span, x + span, n)
+    laplace = 0.5 * a * np.exp(-a * np.abs(theta))
+    normal = np.exp(-0.5 * ((x - theta) / s) ** 2) / (s * math.sqrt(2 * math.pi))
+    return math.log(np.trapezoid(laplace * normal, theta))
+
+
+CASES = [
+    # (x, s, a)
+    (0.0, 1.0, 1.0),
+    (1.5, 1.0, 2.0),
+    (-2.0, 0.5, 1.0),
+    (3.0, 2.0, 0.5),
+    (-0.3, 1.0, 3.0),
+]
+
+
+def test_logg_laplace_matches_brute_force():
+    for x, s, a in CASES:
+        got = float(logg_laplace_convolved_with_normal(_t(x), _t(s), _t(a)))
+        ref = _brute_logg_laplace(x, s, a)
+        assert abs(got - ref) < 1e-3, f"({x},{s},{a}): got {got}, expected {ref}"
+
+
+def test_logg_laplace_matches_internal_slab_term():
+    # The public wrapper must equal the slab log-density from the shared helper.
+    for x, s, a in CASES:
+        wrapper = logg_laplace_convolved_with_normal(_t(x), _t(s), _t(a))
+        lg, _, _ = _laplace_slab_terms(_t(x), _t(s), _t(a))
+        assert torch.equal(wrapper, lg)


### PR DESCRIPTION
**Impact: cosmetic (refactor to a single source of truth, no behavior change).**
Outputs are bit-identical to the originals.

- Add `maths.logg_exp_convolved_with_normal` as the single Exp-prior marginal
  log-density. Route the three copies through it: `utils/distribution_operation.py`,
  `utils/posterior.py` (`posterior_mean_exp`), and `ebnm/point_exp.py`
  (`_loglik_exp_convolved`).
- `point_laplace`: extract `_laplace_slab_terms(x, s, a) -> (lg, lg1, lsum)`; the
  previously-uncalled `logg_laplace_convolved_with_normal` delegates to it, and
  the three inline copies (two marginal-likelihood sites and the posterior site
  that reuses `lg1`/`lsum` for the sign-mixture weight) call it.
- `logPhi` delegates to `_logcdf_normal` so `log Phi` has one implementation.

**Merge order:** independent of #65, #66, #67, #68; merge in any order. #68
removes `wpost_exp`, the last inline copy of this marginal, so merging both
fully completes the consolidation.




